### PR TITLE
refactor(analytics): replace PostHog with Umami

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1147,160 +1147,25 @@
       })();
     </script>
   </body>
-  <!-- PostHog Analytics -->
+  <!-- Umami Analytics -->
   <!-- 本地开发环境（localhost/127.0.0.1）默认不加载，除非 URL 带 report=1 参数 -->
   <script>
     (function () {
       var isLocalDev =
-        window.location.hostname === 'localhost' ||
-        window.location.hostname === '127.0.0.1';
+        window.location.hostname === "localhost" ||
+        window.location.hostname === "127.0.0.1";
       var forceReport =
-        new URLSearchParams(window.location.search).get('report') === '1';
+        new URLSearchParams(window.location.search).get("report") === "1";
 
-      // 本地开发环境且没有 report=1 参数时，不加载 PostHog
       if (isLocalDev && !forceReport) {
         return;
       }
 
-      !(function (t, e) {
-        var o, n, p, r;
-        e.__SV ||
-          (window.posthog && window.posthog.__loaded) ||
-          ((window.posthog = e),
-          (e._i = []),
-          (e.init = function (i, s, a) {
-            function g(t, e) {
-              var o = e.split('.');
-              2 == o.length && ((t = t[o[0]]), (e = o[1])),
-                (t[e] = function () {
-                  t.push([e].concat(Array.prototype.slice.call(arguments, 0)));
-                });
-            }
-            ((p = t.createElement('script')).type = 'text/javascript'),
-              (p.crossOrigin = 'anonymous'),
-              (p.async = !0),
-              (p.src =
-                s.api_host.replace('.i.posthog.com', '-assets.i.posthog.com') +
-                '/static/array.js'),
-              (r = t.getElementsByTagName('script')[0]).parentNode.insertBefore(
-                p,
-                r
-              );
-            var u = e;
-            for (
-              void 0 !== a ? (u = e[a] = []) : (a = 'posthog'),
-                u.people = u.people || [],
-                u.toString = function (t) {
-                  var e = 'posthog';
-                  return (
-                    'posthog' !== a && (e += '.' + a), t || (e += ' (stub)'), e
-                  );
-                },
-                u.people.toString = function () {
-                  return u.toString(1) + '.people (stub)';
-                },
-                o =
-                  'init Dr Ur fi Lr zr ci Or jr capture Ai calculateEventProperties qr register register_once register_for_session unregister unregister_for_session Jr getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty Gr Br createPersonProfile Vr Cr Kr opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing Hr debug O Wr getPageViewId captureTraceFeedback captureTraceMetric Rr'.split(
-                    ' '
-                  ),
-                n = 0;
-              n < o.length;
-              n++
-            )
-              g(u, o[n]);
-            e._i.push([i, s, a]);
-          }),
-          (e.__SV = 1));
-      })(document, window.posthog || []);
-      var isIgnorableExceptionEvent = function (event) {
-        if (!event || event.event !== '$exception') return false;
-        var properties = event.properties || {};
-        var messages = [];
-
-        var appendMessages = function (value) {
-          if (!value) return;
-          if (typeof value === 'string') {
-            messages.push(value);
-            if (
-              value.length < 2000 &&
-              (value.charAt(0) === '[' || value.charAt(0) === '{')
-            ) {
-              try {
-                appendMessages(JSON.parse(value));
-              } catch (_) {}
-            }
-            return;
-          }
-
-          if (Array.isArray(value)) {
-            for (var i = 0; i < value.length; i++) {
-              appendMessages(value[i]);
-            }
-            return;
-          }
-
-          if (typeof value === 'object') {
-            if (typeof value.value === 'string') messages.push(value.value);
-            if (typeof value.message === 'string') messages.push(value.message);
-            if (typeof value.name === 'string') messages.push(value.name);
-          }
-        };
-
-        appendMessages(properties.$exception_values);
-        appendMessages(properties.$exception_list);
-        appendMessages(properties.$exception_message);
-        appendMessages(properties.$exception_type);
-        appendMessages(properties.$exception_types);
-        appendMessages(properties.message);
-        appendMessages(properties.name);
-        appendMessages(event.exception);
-        appendMessages(event.error);
-
-        var text = messages.join('\n');
-        return (
-          text.indexOf(
-            'ResizeObserver loop completed with undelivered notifications'
-          ) !== -1 ||
-          text.indexOf('ResizeObserver loop limit exceeded') !== -1 ||
-          (text.indexOf('WebCodecs API') !== -1 &&
-            (text.indexOf('Chrome 94+') !== -1 ||
-              text.indexOf('Edge 94+') !== -1)) ||
-          (text.indexOf("Failed to execute 'write' on 'Clipboard'") !== -1 &&
-            text.indexOf('permissions policy') !== -1) ||
-          ((text.indexOf('AbortError') !== -1 ||
-            text.indexOf('The user aborted a request') !== -1) &&
-            (text.indexOf("Failed to execute 'showOpenFilePicker'") !== -1 ||
-              text.indexOf("Failed to execute 'showSaveFilePicker'") !== -1 ||
-              text.indexOf('The user aborted a request') !== -1)) ||
-          text.indexOf('No key or key range specified') !== -1
-        );
-      };
-
-      posthog.init('phc_13URtidKwTR9POlwnB153NsN99shRykvPguKWf3vZVn', {
-        api_host: 'https://us.i.posthog.com',
-        defaults: '2025-11-30',
-        person_profiles: 'identified_only',
-        // 关闭 Session Recording，避免 rrweb 主线程开销（wheel/setInterval）与 413
-        disable_session_recording: true,
-        // 限制单次 flush 体积，避免 413 Content Too Large
-        rate_limiting: { events_per_second: 10, events_burst_limit: 30 },
-        request_queue: { flush_interval_ms: 2000 },
-        // 白板 SPA 点击多，关闭 autocapture 减少事件量与请求体
-        autocapture: false,
-        // 静默网络错误；避免 413 重试风暴干扰
-        on_xhr_error: function (err) {
-          var code =
-            err &&
-            (typeof err.statusCode !== 'undefined'
-              ? err.statusCode
-              : err.status);
-          void code;
-        },
-        before_send: function (event) {
-          if (isIgnorableExceptionEvent(event)) return false;
-          return event;
-        },
-      });
+      var script = document.createElement("script");
+      script.defer = true;
+      script.src = "https://umami.tu-zi.com/script.js";
+      script.dataset.websiteId = "e6bd249e-bc68-4857-b6a5-02131b4ea286";
+      document.head.appendChild(script);
     })();
   </script>
 </html>

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1165,6 +1165,7 @@
       script.defer = true;
       script.src = "https://umami.tu-zi.com/script.js";
       script.dataset.websiteId = "e6bd249e-bc68-4857-b6a5-02131b4ea286";
+      script.dataset.excludeSearch = "true";
       document.head.appendChild(script);
     })();
   </script>

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -3,7 +3,7 @@
 # 首页和HTML文件 - 允许iframe嵌入，禁用缓存
 /
   Cache-Control: public, max-age=0, must-revalidate
-  Content-Security-Policy: upgrade-insecure-requests; default-src 'self' https: data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://us.i.posthog.com https://us-assets.i.posthog.com https://wiki.tu-zi.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https: wss: data:; frame-ancestors 'self' localhost:* 127.0.0.1:* *.localhost:* https://api.tu-zi.com;
+  Content-Security-Policy: upgrade-insecure-requests; default-src 'self' https: data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://umami.tu-zi.com https://wiki.tu-zi.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https: wss: data:; frame-ancestors 'self' localhost:* 127.0.0.1:* *.localhost:* https://api.tu-zi.com;
   X-Content-Type-Options: nosniff
   Referrer-Policy: origin-when-cross-origin
 

--- a/apps/web/public/en/home.html
+++ b/apps/web/public/en/home.html
@@ -1194,6 +1194,7 @@
           script.defer = true;
           script.src = "https://umami.tu-zi.com/script.js";
           script.dataset.websiteId = "e6bd249e-bc68-4857-b6a5-02131b4ea286";
+          script.dataset.excludeSearch = "true";
           script.onload = flushPendingEvents;
           document.head.appendChild(script);
         }

--- a/apps/web/public/en/home.html
+++ b/apps/web/public/en/home.html
@@ -1098,18 +1098,6 @@
     <script>
       (function () {
         var pageName = 'opentu_home_seo_en';
-        var posthogKey = 'phc_13URtidKwTR9POlwnB153NsN99shRykvPguKWf3vZVn';
-        var posthogHost = 'https://us.i.posthog.com';
-        var isLocalDev =
-          window.location.hostname === 'localhost' ||
-          window.location.hostname === '127.0.0.1';
-        var forceReport =
-          new URLSearchParams(window.location.search).get('report') === '1';
-
-        if (isLocalDev && !forceReport) {
-          return;
-        }
-
         function sanitizeValue(value) {
           return String(value || '').slice(0, 120);
         }
@@ -1158,12 +1146,40 @@
           };
         }
 
+        var isLocalDev =
+          window.location.hostname === "localhost" ||
+          window.location.hostname === "127.0.0.1";
+        var forceReport =
+          new URLSearchParams(window.location.search).get("report") === "1";
+        var shouldReportAnalytics = !isLocalDev || forceReport;
+        var pendingEvents = [];
+
+        function flushPendingEvents() {
+          if (!window.umami || !window.umami.track) return;
+          while (pendingEvents.length > 0) {
+            var pending = pendingEvents.shift();
+            try {
+              Promise.resolve(
+                window.umami.track(pending.name, pending.properties)
+              ).catch(function () {});
+            } catch (error) {
+              void error;
+            }
+          }
+        }
+
         function track(eventName, properties) {
-          if (!window.posthog || !window.posthog.capture) return;
+          if (!shouldReportAnalytics) return;
+          var enrichedProperties = Object.assign(getCommonProperties(), properties || {});
+          if (!window.umami || !window.umami.track) {
+            if (pendingEvents.length < 20) {
+              pendingEvents.push({ name: eventName, properties: enrichedProperties });
+            }
+            return;
+          }
           try {
-            window.posthog.capture(
-              eventName,
-              Object.assign(getCommonProperties(), properties || {})
+            Promise.resolve(window.umami.track(eventName, enrichedProperties)).catch(
+              function () {}
             );
           } catch (error) {
             void error;
@@ -1171,101 +1187,15 @@
         }
 
         function initAnalytics() {
-          !(function (t, e) {
-            var o, n, p, r;
-            e.__SV ||
-              (window.posthog && window.posthog.__loaded) ||
-              ((window.posthog = e),
-              (e._i = []),
-              (e.init = function (i, s, a) {
-                function g(t, e) {
-                  var o = e.split('.');
-                  2 == o.length && ((t = t[o[0]]), (e = o[1])),
-                    (t[e] = function () {
-                      t.push(
-                        [e].concat(Array.prototype.slice.call(arguments, 0))
-                      );
-                    });
-                }
-                ((p = t.createElement('script')).type = 'text/javascript'),
-                  (p.crossOrigin = 'anonymous'),
-                  (p.async = !0),
-                  (p.src =
-                    s.api_host.replace(
-                      '.i.posthog.com',
-                      '-assets.i.posthog.com'
-                    ) + '/static/array.js'),
-                  (r =
-                    t.getElementsByTagName(
-                      'script'
-                    )[0]).parentNode.insertBefore(p, r);
-                var u = e;
-                for (
-                  void 0 !== a ? (u = e[a] = []) : (a = 'posthog'),
-                    u.people = u.people || [],
-                    u.toString = function (t) {
-                      var e = 'posthog';
-                      return (
-                        'posthog' !== a && (e += '.' + a),
-                        t || (e += ' (stub)'),
-                        e
-                      );
-                    },
-                    u.people.toString = function () {
-                      return u.toString(1) + '.people (stub)';
-                    },
-                    o =
-                      'init capture register register_once unregister identify reset get_distinct_id get_session_id opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing'.split(
-                        ' '
-                      ),
-                    n = 0;
-                  n < o.length;
-                  n++
-                )
-                  g(u, o[n]);
-                e._i.push([i, s, a]);
-              }),
-              (e.__SV = 1));
-          })(document, window.posthog || []);
-
-          window.posthog.init(posthogKey, {
-            api_host: posthogHost,
-            defaults: '2025-11-30',
-            person_profiles: 'identified_only',
-            disable_session_recording: true,
-            autocapture: false,
-            capture_pageview: false,
-            rate_limiting: { events_per_second: 5, events_burst_limit: 15 },
-            request_queue: { flush_interval_ms: 2000 },
-          });
-
-          clearHomeSuperProperties();
-        }
-
-        function clearHomeSuperProperties() {
-          if (!window.posthog || !window.posthog.unregister) return;
-
-          [
-            'page_name',
-            'page_path',
-            'page_title',
-            'page_language',
-            'landing_page',
-            'referrer_host',
-            'search_engine',
-            'utm_source',
-            'utm_medium',
-            'utm_campaign',
-            'primary_image_model',
-            'primary_reasoning_model',
-            'content_variant',
-          ].forEach(function (key) {
-            try {
-              window.posthog.unregister(key);
-            } catch (error) {
-              void error;
-            }
-          });
+          if (!shouldReportAnalytics || document.querySelector("script[data-website-id=\"e6bd249e-bc68-4857-b6a5-02131b4ea286\"]")) {
+            return;
+          }
+          var script = document.createElement("script");
+          script.defer = true;
+          script.src = "https://umami.tu-zi.com/script.js";
+          script.dataset.websiteId = "e6bd249e-bc68-4857-b6a5-02131b4ea286";
+          script.onload = flushPendingEvents;
+          document.head.appendChild(script);
         }
 
         function scheduleWhenIdle(callback, timeout) {

--- a/apps/web/public/home.html
+++ b/apps/web/public/home.html
@@ -1150,14 +1150,9 @@
     <script>
       (function () {
         var pageName = 'opentu_home_seo';
-        var posthogKey = 'phc_13URtidKwTR9POlwnB153NsN99shRykvPguKWf3vZVn';
-        var posthogHost = 'https://us.i.posthog.com';
-        var isLocalDev =
-          window.location.hostname === 'localhost' ||
-          window.location.hostname === '127.0.0.1';
-        var forceReport =
-          new URLSearchParams(window.location.search).get('report') === '1';
-        var shouldReportAnalytics = !isLocalDev || forceReport;
+        function sanitizeValue(value) {
+          return String(value || '').slice(0, 120);
+        }
 
         function getSearchEngine() {
           var referrer = document.referrer || '';
@@ -1174,10 +1169,6 @@
           } catch (error) {
             return '';
           }
-        }
-
-        function sanitizeValue(value) {
-          return String(value || '').slice(0, 120);
         }
 
         function getCommonProperties() {
@@ -1206,13 +1197,40 @@
           };
         }
 
+        var isLocalDev =
+          window.location.hostname === "localhost" ||
+          window.location.hostname === "127.0.0.1";
+        var forceReport =
+          new URLSearchParams(window.location.search).get("report") === "1";
+        var shouldReportAnalytics = !isLocalDev || forceReport;
+        var pendingEvents = [];
+
+        function flushPendingEvents() {
+          if (!window.umami || !window.umami.track) return;
+          while (pendingEvents.length > 0) {
+            var pending = pendingEvents.shift();
+            try {
+              Promise.resolve(
+                window.umami.track(pending.name, pending.properties)
+              ).catch(function () {});
+            } catch (error) {
+              void error;
+            }
+          }
+        }
+
         function track(eventName, properties) {
           if (!shouldReportAnalytics) return;
-          if (!window.posthog || !window.posthog.capture) return;
+          var enrichedProperties = Object.assign(getCommonProperties(), properties || {});
+          if (!window.umami || !window.umami.track) {
+            if (pendingEvents.length < 20) {
+              pendingEvents.push({ name: eventName, properties: enrichedProperties });
+            }
+            return;
+          }
           try {
-            window.posthog.capture(
-              eventName,
-              Object.assign(getCommonProperties(), properties || {})
+            Promise.resolve(window.umami.track(eventName, enrichedProperties)).catch(
+              function () {}
             );
           } catch (error) {
             void error;
@@ -1220,104 +1238,15 @@
         }
 
         function initAnalytics() {
-          if (!shouldReportAnalytics) {
+          if (!shouldReportAnalytics || document.querySelector("script[data-website-id=\"e6bd249e-bc68-4857-b6a5-02131b4ea286\"]")) {
             return;
           }
-
-          !(function (t, e) {
-            var o, n, p, r;
-            e.__SV ||
-              (window.posthog && window.posthog.__loaded) ||
-              ((window.posthog = e),
-              (e._i = []),
-              (e.init = function (i, s, a) {
-                function g(t, e) {
-                  var o = e.split('.');
-                  2 == o.length && ((t = t[o[0]]), (e = o[1])),
-                    (t[e] = function () {
-                      t.push(
-                        [e].concat(Array.prototype.slice.call(arguments, 0))
-                      );
-                    });
-                }
-                ((p = t.createElement('script')).type = 'text/javascript'),
-                  (p.crossOrigin = 'anonymous'),
-                  (p.async = !0),
-                  (p.src =
-                    s.api_host.replace(
-                      '.i.posthog.com',
-                      '-assets.i.posthog.com'
-                    ) + '/static/array.js'),
-                  (r =
-                    t.getElementsByTagName(
-                      'script'
-                    )[0]).parentNode.insertBefore(p, r);
-                var u = e;
-                for (
-                  void 0 !== a ? (u = e[a] = []) : (a = 'posthog'),
-                    u.people = u.people || [],
-                    u.toString = function (t) {
-                      var e = 'posthog';
-                      return (
-                        'posthog' !== a && (e += '.' + a),
-                        t || (e += ' (stub)'),
-                        e
-                      );
-                    },
-                    u.people.toString = function () {
-                      return u.toString(1) + '.people (stub)';
-                    },
-                    o =
-                      'init capture register register_once unregister identify reset get_distinct_id get_session_id opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing'.split(
-                        ' '
-                      ),
-                    n = 0;
-                  n < o.length;
-                  n++
-                )
-                  g(u, o[n]);
-                e._i.push([i, s, a]);
-              }),
-              (e.__SV = 1));
-          })(document, window.posthog || []);
-
-          window.posthog.init(posthogKey, {
-            api_host: posthogHost,
-            defaults: '2025-11-30',
-            person_profiles: 'identified_only',
-            disable_session_recording: true,
-            autocapture: false,
-            capture_pageview: false,
-            rate_limiting: { events_per_second: 5, events_burst_limit: 15 },
-            request_queue: { flush_interval_ms: 2000 },
-          });
-
-          clearHomeSuperProperties();
-        }
-
-        function clearHomeSuperProperties() {
-          if (!window.posthog || !window.posthog.unregister) return;
-
-          [
-            'page_name',
-            'page_path',
-            'page_title',
-            'landing_page',
-            'referrer_host',
-            'search_engine',
-            'utm_source',
-            'utm_medium',
-            'utm_campaign',
-            'primary_image_model',
-            'primary_reasoning_model',
-            'content_variant',
-          ].forEach(function (key) {
-            try {
-              window.posthog.unregister(key);
-            } catch (error) {
-              void error;
-            }
-          });
+          var script = document.createElement("script");
+          script.defer = true;
+          script.src = "https://umami.tu-zi.com/script.js";
+          script.dataset.websiteId = "e6bd249e-bc68-4857-b6a5-02131b4ea286";
+          script.onload = flushPendingEvents;
+          document.head.appendChild(script);
         }
 
         function scheduleWhenIdle(callback, timeout) {

--- a/apps/web/public/home.html
+++ b/apps/web/public/home.html
@@ -1245,6 +1245,7 @@
           script.defer = true;
           script.src = "https://umami.tu-zi.com/script.js";
           script.dataset.websiteId = "e6bd249e-bc68-4857-b6a5-02131b4ea286";
+          script.dataset.excludeSearch = "true";
           script.onload = flushPendingEvents;
           document.head.appendChild(script);
         }

--- a/apps/web/public/sw-debug/common.js
+++ b/apps/web/public/sw-debug/common.js
@@ -5,7 +5,7 @@
 
 /**
  * Escape HTML special characters
- * @param {string} str 
+ * @param {string} str
  * @returns {string}
  */
 export function escapeHtml(str) {
@@ -20,8 +20,8 @@ export function escapeHtml(str) {
 
 /**
  * Truncate URL for display
- * @param {string} url 
- * @param {number} maxLen 
+ * @param {string} url
+ * @param {number} maxLen
  * @returns {string}
  */
 export function truncateUrl(url, maxLen) {
@@ -48,7 +48,7 @@ export function formatBytes(bytes) {
 export function parseUserAgent(ua) {
   let browser = '未知';
   let os = '未知';
-  
+
   // Detect browser
   if (ua.includes('Chrome') && !ua.includes('Edg')) {
     const match = ua.match(/Chrome\/(\d+)/);
@@ -63,7 +63,7 @@ export function parseUserAgent(ua) {
     const match = ua.match(/Version\/(\d+)/);
     browser = match ? `Safari ${match[1]}` : 'Safari';
   }
-  
+
   // Detect OS
   if (ua.includes('Windows NT 10')) {
     os = 'Windows 10/11';
@@ -81,22 +81,20 @@ export function parseUserAgent(ua) {
     const match = ua.match(/OS (\d+)/);
     os = match ? `iOS ${match[1]}` : 'iOS';
   }
-  
+
   return { browser, os };
 }
 
 // Domain blacklist - requests from these domains will be hidden
 export const DOMAIN_BLACKLIST = [
-  'us.i.posthog.com',
-  'us-assets.i.posthog.com',
-  'posthog.com',
+  'umami.tu-zi.com',
   'google-analytics.com',
   'googletagmanager.com',
 ];
 
 /**
  * Check if URL is in the domain blacklist
- * @param {string} url 
+ * @param {string} url
  * @returns {boolean}
  */
 export function isBlacklistedUrl(url) {
@@ -113,16 +111,16 @@ export function isBlacklistedUrl(url) {
 
 /**
  * Filter logs by time range
- * @param {Array} logs 
+ * @param {Array} logs
  * @param {string} timeRangeMinutes - Minutes as string, or empty for all
  * @returns {Array}
  */
 export function filterByTimeRange(logs, timeRangeMinutes) {
   if (!timeRangeMinutes) return logs;
-  
+
   const minutes = parseInt(timeRangeMinutes);
   if (isNaN(minutes)) return logs;
-  
+
   const cutoffTime = Date.now() - (minutes * 60 * 1000);
   return logs.filter(log => log.timestamp >= cutoffTime);
 }
@@ -157,12 +155,12 @@ function isBase64Image(str) {
 function getBase64ImageInfo(base64Str) {
   const match = base64Str.match(/^data:image\/([^;]+);base64,(.*)$/);
   if (!match) return { mimeType: 'unknown', size: 0 };
-  
+
   const mimeType = match[1];
   const base64Data = match[2];
   // 估算原始文件大小（base64 会增加约 33% 的大小）
   const size = Math.round((base64Data.length * 3) / 4);
-  
+
   return { mimeType, size };
 }
 
@@ -183,7 +181,7 @@ function createBase64ImagePreview(base64Str) {
   const { mimeType, size } = getBase64ImageInfo(base64Str);
   const sizeText = formatBytes(size);
   const previewId = generateImagePreviewId();
-  
+
   // 创建一个可展开的图片预览组件
   return `<span class="base64-image-preview" data-preview-id="${previewId}">
     <span class="base64-preview-toggle" onclick="toggleBase64Preview('${previewId}')" title="点击展开/收起图片预览">
@@ -204,7 +202,7 @@ function createBase64ImagePreview(base64Str) {
  */
 function processObjectForBase64(obj, imageMap, path = '') {
   if (obj === null || obj === undefined) return obj;
-  
+
   if (typeof obj === 'string') {
     if (isBase64Image(obj)) {
       const placeholder = `__BASE64_IMAGE_${imageMap.size}__`;
@@ -213,11 +211,11 @@ function processObjectForBase64(obj, imageMap, path = '') {
     }
     return obj;
   }
-  
+
   if (Array.isArray(obj)) {
     return obj.map((item, index) => processObjectForBase64(item, imageMap, `${path}[${index}]`));
   }
-  
+
   if (typeof obj === 'object') {
     const result = {};
     for (const [key, value] of Object.entries(obj)) {
@@ -225,7 +223,7 @@ function processObjectForBase64(obj, imageMap, path = '') {
     }
     return result;
   }
-  
+
   return obj;
 }
 
@@ -237,17 +235,17 @@ function processObjectForBase64(obj, imageMap, path = '') {
  */
 export function formatJsonWithHighlight(jsonStr) {
   if (!jsonStr) return '';
-  
+
   try {
     // Try to parse and re-stringify with indentation
     const parsed = JSON.parse(jsonStr);
-    
+
     // 收集并替换 base64 图片
     const imageMap = new Map();
     const processedObj = processObjectForBase64(parsed, imageMap);
-    
+
     const formatted = JSON.stringify(processedObj, null, 2);
-    
+
     // Apply syntax highlighting
     let highlighted = escapeHtml(formatted)
       .replace(/"([^"]+)":/g, '<span class="json-key">"$1"</span>:')
@@ -255,7 +253,7 @@ export function formatJsonWithHighlight(jsonStr) {
       .replace(/: (\d+\.?\d*)/g, ': <span class="json-number">$1</span>')
       .replace(/: (true|false)/g, ': <span class="json-boolean">$1</span>')
       .replace(/: (null)/g, ': <span class="json-null">$1</span>');
-    
+
     // 将占位符替换为图片预览组件
     for (const [placeholder, base64Str] of imageMap) {
       const escapedPlaceholder = escapeHtml(placeholder);
@@ -266,7 +264,7 @@ export function formatJsonWithHighlight(jsonStr) {
         imagePreviewHtml
       );
     }
-    
+
     return highlighted;
   } catch {
     // If not valid JSON, just escape and return
@@ -281,7 +279,7 @@ export function formatJsonWithHighlight(jsonStr) {
  */
 export function extractRequestParams(requestBody) {
   if (!requestBody) return {};
-  
+
   try {
     const parsed = JSON.parse(requestBody);
     return {

--- a/apps/web/src/app/bootstrap.tsx
+++ b/apps/web/src/app/bootstrap.tsx
@@ -16,10 +16,7 @@ import {
   swChannelClient,
   safeReload,
 } from '@drawnix/drawnix/runtime';
-import {
-  getAnalyticsReleaseContext,
-  registerAnalyticsSuperProperties,
-} from '@drawnix/drawnix';
+import { analytics } from '@drawnix/drawnix';
 import { initSWConsoleCapture } from '../utils/sw-console-capture';
 
 const isLocalDev =
@@ -51,11 +48,6 @@ crashRecoveryService.checkUrlSafeMode();
 // 必须尽早初始化，以捕获启动阶段的内存状态和错误
 initCrashLogger();
 
-const APP_VERSION =
-  import.meta.env.VITE_APP_VERSION ||
-  document.querySelector('meta[name="app-version"]')?.getAttribute('content') ||
-  '0.0.0';
-const RELEASE_CONTEXT = getAnalyticsReleaseContext();
 const LAZY_CHUNK_RETRY_PARAM = '_lazy_chunk_retry';
 const LAZY_CHUNK_RETRY_TS_PARAM = '_t';
 
@@ -178,17 +170,20 @@ updateBootStatus({
 if (typeof window !== 'undefined') {
   initPreventPinchZoom();
 
-  const initPostHogContext = () => {
-    if (window.posthog) {
-      registerAnalyticsSuperProperties(RELEASE_CONTEXT);
+  const initAnalyticsMonitoring = (attempt = 0) => {
+    if (analytics.isAnalyticsEnabled()) {
       initPageReport();
       return;
     }
 
-    setTimeout(initPostHogContext, 300);
+    // Do not keep polling forever when reporting is disabled or blocked.
+    if (attempt >= 10) {
+      return;
+    }
+    setTimeout(() => initAnalyticsMonitoring(attempt + 1), 300);
   };
 
-  scheduleAfterFirstFrameIdle(initPostHogContext, {
+  scheduleAfterFirstFrameIdle(() => initAnalyticsMonitoring(), {
     delay: 0,
     timeout: 1000,
   });
@@ -229,12 +224,17 @@ if (typeof window !== 'undefined') {
   );
 
   // 统计上报为旁路逻辑：page view 尽早初始化，性能指标继续延迟
-  const initMonitoring = () => {
-    if (window.posthog) {
+  const initMonitoring = (attempt = 0) => {
+    if (analytics.isAnalyticsEnabled()) {
       initWebVitals();
-    } else {
-      setTimeout(initMonitoring, 500);
+      return;
     }
+
+    // Give the deferred Umami script a bounded window to initialize.
+    if (attempt >= 10) {
+      return;
+    }
+    setTimeout(() => initMonitoring(attempt + 1), 300);
   };
 
   scheduleAfterFirstFrameIdle(initMonitoring, {
@@ -243,10 +243,7 @@ if (typeof window !== 'undefined') {
   });
 }
 
-if (
-  hasServiceWorkerSupport &&
-  isServiceWorkerExplicitlyDisabled
-) {
+if (hasServiceWorkerSupport && isServiceWorkerExplicitlyDisabled) {
   cleanupDisabledServiceWorker();
 }
 

--- a/apps/web/src/crash-logger.ts
+++ b/apps/web/src/crash-logger.ts
@@ -739,10 +739,10 @@ export function setupErrorCapture(): void {
       return;
     }
 
-    // 过滤监控服务相关的错误（PostHog）
+    // 过滤监控服务相关的错误（Umami）
     if (
-      errorMessage.includes('posthog.com') ||
-      errorStack.includes('posthog')
+      errorMessage.includes('umami.tu-zi.com') ||
+      errorStack.includes('umami')
     ) {
       return; // 静默忽略监控服务的网络错误
     }

--- a/apps/web/src/sw/index.ts
+++ b/apps/web/src/sw/index.ts
@@ -4256,9 +4256,9 @@ sw.addEventListener('fetch', (event: FetchEvent) => {
   // 而是在 handleImageRequest 中跳过缓存检查直接 fetch，但仍会缓存响应
   // 这样可以确保绕过请求的响应也能被缓存，供后续正常请求使用
 
-  // 放行监控服务域名（PostHog），让浏览器直接处理
+  // 放行监控服务域名（Umami），让浏览器直接处理
   // 这些服务的请求失败不应该影响应用，也不需要记录到调试日志
-  if (url.hostname.endsWith('.posthog.com')) {
+  if (url.hostname === 'umami.tu-zi.com') {
     return; // 静默放行，不记录日志
   }
 

--- a/apps/web/src/utils/sw-console-capture.ts
+++ b/apps/web/src/utils/sw-console-capture.ts
@@ -78,8 +78,11 @@ function sendToSW(level: string, message: string, stack?: string) {
     return;
   }
 
-  // 过滤监控服务相关的错误（PostHog）
-  if (message.includes('posthog.com') || (stack && stack.includes('posthog'))) {
+  // 过滤监控服务相关的错误（Umami）
+  if (
+    message.includes('umami.tu-zi.com') ||
+    (stack && stack.includes('umami'))
+  ) {
     return;
   }
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1030,7 +1030,7 @@ export default defineConfig({
     host: 'localhost',
     headers: {
       'Content-Security-Policy':
-        "default-src 'self' https: data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://us.i.posthog.com https://us-assets.i.posthog.com https://wiki.tu-zi.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' http: https: ws: wss: data:; frame-ancestors 'self' localhost:* 127.0.0.1:* https://api.tu-zi.com;",
+        "default-src 'self' https: data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://umami.tu-zi.com https://wiki.tu-zi.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' http: https: ws: wss: data:; frame-ancestors 'self' localhost:* 127.0.0.1:* https://api.tu-zi.com;",
     },
     // dev 代理：让图片提交请求在本地开发环境按同源方式携带 X-Request-Id
     // 只允许固定 Tuzi 节点，保留原 Token、计费和权限域。
@@ -1081,7 +1081,7 @@ export default defineConfig({
     host: 'localhost',
     headers: {
       'Content-Security-Policy':
-        "upgrade-insecure-requests; default-src 'self' https: data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://us.i.posthog.com https://us-assets.i.posthog.com https://wiki.tu-zi.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https: wss: data:; frame-ancestors 'self' localhost:* 127.0.0.1:* https://api.tu-zi.com;",
+        "upgrade-insecure-requests; default-src 'self' https: data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://umami.tu-zi.com https://wiki.tu-zi.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https: wss: data:; frame-ancestors 'self' localhost:* 127.0.0.1:* https://api.tu-zi.com;",
     },
   },
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -24,7 +24,7 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self' https: data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://us.i.posthog.com https://us-assets.i.posthog.com https://wiki.tu-zi.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https: wss: data: blob:; frame-ancestors 'self' localhost:* 127.0.0.1:* *.localhost:* https://api.tu-zi.com;"
+    Content-Security-Policy = "default-src 'self' https: data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://umami.tu-zi.com https://wiki.tu-zi.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https: wss: data: blob:; frame-ancestors 'self' localhost:* 127.0.0.1:* *.localhost:* https://api.tu-zi.com;"
     X-XSS-Protection = "1; mode=block"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "origin-when-cross-origin"

--- a/openspec/changes/replace-posthog-with-umami-analytics/design.md
+++ b/openspec/changes/replace-posthog-with-umami-analytics/design.md
@@ -1,0 +1,73 @@
+## Context
+
+当前统计链路由 `apps/web/index.html` 中的 PostHog loader、`packages/drawnix/src/utils/posthog-analytics.ts`、声明式 `posthog-adapter.ts` 和多个业务调用方组成。启动代码会等待 `window.posthog` 后初始化页面报告和 Web Vitals。静态中英文首页、CSP、Service Worker 和错误日志过滤还各自包含 PostHog 专属逻辑。
+
+Umami 提供浏览器脚本和 `window.umami.track(eventName, eventData)` 接口，但没有 PostHog `register()` 的同等超属性机制，也不会识别 `$web_vitals`、`$ai_generation` 等 PostHog 专属事件语义。
+
+## Goals / Non-Goals
+
+- Goals:
+  - 让生产 Web 端只向 Umami 上报统计。
+  - 保留当前业务统计方法和事件名称，减少调用方行为变化。
+  - 保留现有脱敏、版本、环境、域名和路由上下文。
+  - 统一页面访问口径，避免 Umami 自动 pageview 与手动基础 pageview 重复。
+  - SDK 不可用时不影响应用启动。
+- Non-Goals:
+  - 不恢复历史旧版 Umami 实现。
+  - 不重做声明式 tracking 功能或增加新的事件覆盖范围。
+  - 不把历史文档中的 PostHog 内容当作当前运行时依赖处理。
+
+## Decisions
+
+### 1. 直接迁移现有统计工具
+
+将 `posthog-analytics.ts` 改为 Umami 实现并保留其公开业务方法；将 `posthog-adapter.ts` 改为 `umami-adapter.ts`，同步更新插件出口、调用方和测试 mock。该方案不引入新的供应商抽象层，符合已确定的直接迁移范围。
+
+### 2. 每个事件携带公共上下文
+
+保留现有 `getAnalyticsReleaseContext()` 的数据模型，在每次 `track()` 时合并版本、部署环境、host、hostname 和 route_name。移除 `registerAnalyticsSuperProperties()` 及启动阶段对 `window.posthog.register()` 的依赖。
+
+### 3. 页面访问由 Umami 自动 pageview 负责
+
+使用 Umami tracker 的默认 pageview 能力，停止 `page-report-service` 中重复的基础 `app_page_view` 上报；保留页面性能和 Web Vitals 作为自定义事件。若后续仍需完整设备/视口页面数据，应使用不同的明确事件名，不能与标准 pageview 混用。
+
+### 4. 保留本地统计开关语义
+
+继续支持当前本地开发默认不加载统计、通过 `report=1` 显式启用的行为，避免开发数据污染生产统计。Umami 脚本加载失败或未完成初始化时，统计调用静默跳过且不阻塞启动。
+
+### 5. 统一部署和 Service Worker 允许列表
+
+从 `script-src`、`connect-src` 和 Service Worker 监控服务放行/调试黑名单中移除 PostHog 域名，加入 `umami.tu-zi.com` 所需规则。验证 Netlify、Vite dev/preview 和静态首页实际响应头均一致。
+
+### 6. 处理异步和批量结果
+
+Umami adapter 需要兼容 `track()` 返回 `void` 或 Promise 的 SDK 形态。批量服务必须等待可等待结果，不能把“调用已发起”误判为“上报成功”；保留现有内存重试边界，不在本次迁移中扩展离线持久化。
+
+## Risks / Trade-offs
+
+- Umami 不提供 PostHog 专属事件解析，历史 `$web_vitals` 和 `$ai_generation` 只能作为普通事件保留。
+  - Mitigation: 保留事件名和字段，更新文档与验证口径。
+- 自动 pageview 和现有手动页面统计可能重复。
+  - Mitigation: 由 Umami 负责标准 pageview，关闭重复的基础手动 pageview。
+- 全仓库导入和测试 mock 数量较多，遗漏会导致构建或运行时仍引用 PostHog。
+  - Mitigation: 使用全仓库 `rg` 扫描，并在构建产物和浏览器网络面板中确认无 PostHog 请求。
+- Umami 脚本被网络策略拦截时，部分低频事件会丢失。
+  - Mitigation: 统计逻辑旁路化、设置有限等待/重试，不影响主业务。
+
+## Migration Plan
+
+1. 审批本变更提案。
+2. 替换 Umami 核心工具、adapter、启动检查和所有调用方导入。
+3. 替换应用入口及中英文静态首页的 tracker。
+4. 更新 CSP、Service Worker、错误过滤和测试 mock。
+5. 调整页面访问和性能事件，完成类型检查、测试、构建与浏览器网络验证。
+6. 确认生产环境无 PostHog 请求后再发布。
+
+## Rollback
+
+若 Umami 上报或构建验证失败，可回滚本次变更提交，恢复 PostHog 入口、adapter、CSP 和启动检查；不涉及数据库或用户本地业务数据迁移。
+
+## Open Questions
+
+- Umami 后台是否需要保留现有 `app_page_view` 的完整设备/视口字段；当前方案默认不再重复上报基础页面访问。
+- `report=1` 是否继续允许在预览环境启用统计；当前方案默认保留现有行为。

--- a/openspec/changes/replace-posthog-with-umami-analytics/proposal.md
+++ b/openspec/changes/replace-posthog-with-umami-analytics/proposal.md
@@ -1,0 +1,26 @@
+# Change: 将统计上报从 PostHog 迁移到 Umami
+
+## Why
+
+当前 Opentu 的 Web 端使用 PostHog 进行页面访问、AI 生成、UI 操作、PPT、提示词、页面性能和 Web Vitals 统计。原 PostHog 服务成本发生变化，需要迁移到项目提供的 Umami 服务 `https://umami.tu-zi.com`，同时停止浏览器继续加载或请求 PostHog。
+
+## What Changes
+
+- 在 Web 入口接入 Umami tracker，使用 website ID `e6bd249e-bc68-4857-b6a5-02131b4ea286`。
+- 将现有业务统计工具和声明式 tracking adapter 的底层实现切换为 `window.umami.track()`。
+- 保留现有业务事件名称、事件分类、脱敏规则、版本/环境/路由上下文和主要统计覆盖范围。
+- 处理 Umami 与 PostHog 的差异：移除 PostHog `register()` 和特殊事件语义，避免自动 pageview 与手动页面访问重复上报，并正确处理 SDK 未加载和异步失败。
+- 删除运行时代码、静态首页、CSP、Service Worker、错误过滤和测试中的 PostHog 专属代码与域名配置。
+
+## Non-Goals
+
+- 不新增自动识别所有可点击元素的埋点能力。
+- 不改变现有业务事件的触发时机或产品交互。
+- 不删除 CHANGELOG 和历史复盘文档中的历史 PostHog 记录。
+- 不引入可在运行时切换多个统计供应商的通用平台。
+
+## Impact
+
+- Affected specs: `analytics-reporting`
+- Affected code: `apps/web`, `packages/drawnix`, `netlify.toml`, `openspec`
+- External service: `https://umami.tu-zi.com/script.js`

--- a/openspec/changes/replace-posthog-with-umami-analytics/specs/analytics-reporting/spec.md
+++ b/openspec/changes/replace-posthog-with-umami-analytics/specs/analytics-reporting/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: Web analytics SHALL report through Umami
+
+The Web application SHALL load the configured Umami tracker from `https://umami.tu-zi.com/script.js` with website ID `e6bd249e-bc68-4857-b6a5-02131b4ea286`, and runtime analytics events SHALL be sent through `window.umami.track()`.
+
+#### Scenario: Production tracker loads
+
+- **GIVEN** the Web application runs in a reporting-enabled deployment
+- **WHEN** the document finishes loading
+- **THEN** the Umami tracker SHALL be available for pageview and custom-event reporting
+- **AND** the application SHALL NOT initialize the PostHog tracker
+
+#### Scenario: Analytics provider is unavailable
+
+- **GIVEN** the Umami script is blocked, fails, or has not finished loading
+- **WHEN** application code requests an analytics event
+- **THEN** the event call SHALL not throw into the user workflow
+- **AND** application startup and business operations SHALL continue
+
+### Requirement: Existing business event coverage SHALL survive provider migration
+
+The migration SHALL preserve existing business-facing analytics method names, event names, sanitized prompt summaries, and release context fields unless a field is explicitly incompatible with Umami.
+
+#### Scenario: AI generation event
+
+- **WHEN** an image, video, audio, or chat generation starts, succeeds, fails, or is cancelled
+- **THEN** the corresponding existing event name SHALL be sent as an Umami custom event
+- **AND** the event SHALL contain the existing non-sensitive task and model fields
+
+#### Scenario: Prompt data is reported safely
+
+- **WHEN** a prompt or requirements value is used for analytics
+- **THEN** the event SHALL report only the existing summary fields such as length and line count
+- **AND** raw prompt text SHALL NOT be sent
+
+#### Scenario: Release context is attached
+
+- **WHEN** a custom analytics event is sent
+- **THEN** the event SHALL include version, deployment environment, host, hostname, and route context
+- **AND** the implementation SHALL NOT depend on PostHog `register()` semantics
+
+### Requirement: Pageview and performance reporting SHALL have one clear owner
+
+The system SHALL avoid counting the same pageview through both Umami automatic pageviews and the existing manual basic pageview event.
+
+#### Scenario: Initial and SPA pageview
+
+- **WHEN** a reporting-enabled page is initially loaded or the SPA route changes
+- **THEN** the standard pageview SHALL be owned by the configured Umami tracker
+- **AND** the application SHALL NOT emit a duplicate basic pageview solely through `app_page_view`
+
+#### Scenario: Performance metrics
+
+- **WHEN** page performance or Web Vitals are available
+- **THEN** the application SHALL continue to report them as Umami custom events
+- **AND** those events SHALL remain distinct from standard pageviews
+
+### Requirement: PostHog runtime integration SHALL be removed
+
+The Web application SHALL not load, call, allowlist, or silently filter PostHog as part of the active analytics implementation.
+
+#### Scenario: Deployment policy is updated
+
+- **WHEN** production or preview security headers are generated
+- **THEN** the headers SHALL allow the configured Umami script and connection endpoints as required
+- **AND** they SHALL not contain active PostHog analytics domains
+
+#### Scenario: Service Worker observes analytics traffic
+
+- **WHEN** the Service Worker handles an Umami or analytics-related request
+- **THEN** it SHALL apply the intended pass-through/debug policy without routing the request through media caching
+- **AND** no PostHog-specific runtime branch SHALL remain

--- a/openspec/changes/replace-posthog-with-umami-analytics/tasks.md
+++ b/openspec/changes/replace-posthog-with-umami-analytics/tasks.md
@@ -1,0 +1,29 @@
+## 1. OpenSpec and provider entry
+
+- [x] 1.1 审批 `replace-posthog-with-umami-analytics` 提案
+- [x] 1.2 在 `apps/web/index.html` 接入 Umami tracker 和 website ID
+- [x] 1.3 替换 `apps/web/public/home.html` 与 `apps/web/public/en/home.html` 中的 PostHog 初始化
+
+## 2. Runtime analytics migration
+
+- [x] 2.1 将 `posthog-analytics.ts` 迁移为 Umami 实现并保留现有业务方法
+- [x] 2.2 将 `posthog-adapter.ts` 迁移为 Umami adapter，更新插件出口和 batch service
+- [x] 2.3 批量更新业务源码、测试和 mock 的导入路径与 provider 命名
+- [x] 2.4 移除 `registerAnalyticsSuperProperties` 和 `window.posthog` 启动轮询
+- [x] 2.5 保留脱敏、公共上下文和有限的 SDK 未加载保护
+- [x] 2.6 调整页面访问、页面性能和 Web Vitals 事件，避免标准 pageview 重复
+
+## 3. Runtime and deployment cleanup
+
+- [x] 3.1 从 `netlify.toml`、`apps/web/public/_headers` 和 Vite dev/preview CSP 中移除 PostHog，加入 Umami
+- [x] 3.2 更新 Service Worker 的监控域名放行和调试黑名单
+- [x] 3.3 更新 crash logger、SW console capture 和运行时注释中的 provider 过滤
+- [x] 3.4 保留历史 CHANGELOG/复盘文档，不把历史记录误删为运行时代码
+
+## 4. Verification
+
+- [x] 4.1 全仓库扫描确认运行时代码、配置和测试不再引用 PostHog
+- [x] 4.2 运行 `git diff --check`
+- [x] 4.3 运行相关单元测试、类型检查、Lint 和 Web 构建
+- [ ] 4.4 浏览器验证 Umami 脚本、页面访问、自定义事件和 Web Vitals 请求
+- [ ] 4.5 验证浏览器网络面板中没有 PostHog 请求，且 Umami 故障不阻塞应用启动

--- a/packages/drawnix/src/components/ai-input-bar/AIInputBar.tsx
+++ b/packages/drawnix/src/components/ai-input-bar/AIInputBar.tsx
@@ -166,7 +166,7 @@ import type {
 import {
   analytics,
   type PromptAnalyticsType,
-} from '../../utils/posthog-analytics';
+} from '../../utils/umami-analytics';
 import classNames from 'classnames';
 import { InspirationBoard } from '../inspiration-board';
 import { AIInputComposerShell } from './AIInputComposerShell';

--- a/packages/drawnix/src/components/ai-input-bar/PromptHistoryPopover.tsx
+++ b/packages/drawnix/src/components/ai-input-bar/PromptHistoryPopover.tsx
@@ -26,7 +26,7 @@ import {
   resolvePromptItemsByGenerationType,
   type ResolvedPromptItem,
 } from '../ttd-dialog/shared/prompt-utils';
-import { analytics } from '../../utils/posthog-analytics';
+import { analytics } from '../../utils/umami-analytics';
 import './prompt-history-popover.scss';
 
 /** 选择提示词回调的参数类型 */

--- a/packages/drawnix/src/components/character/CharacterMentionPopup.tsx
+++ b/packages/drawnix/src/components/character/CharacterMentionPopup.tsx
@@ -7,7 +7,7 @@
 
 import React, { useCallback, useMemo, useEffect, useRef } from 'react';
 import { useCharacters } from '../../hooks/useCharacters';
-import { analytics } from '../../utils/posthog-analytics';
+import { analytics } from '../../utils/umami-analytics';
 import type { SoraCharacter } from '../../types/character.types';
 import { CharacterAvatar } from './CharacterAvatar';
 import { Z_INDEX } from '../../constants/z-index';

--- a/packages/drawnix/src/components/chat-drawer/ChatDrawer.tsx
+++ b/packages/drawnix/src/components/chat-drawer/ChatDrawer.tsx
@@ -50,7 +50,7 @@ import {
   shouldUseImplicitWorkflowReferences,
 } from './workflow-media-results';
 
-import { analytics } from '../../utils/posthog-analytics';
+import { analytics } from '../../utils/umami-analytics';
 import { HoverTip } from '../shared';
 import './chat-drawer.scss';
 

--- a/packages/drawnix/src/components/comic-creator/ComicCreator.tsx
+++ b/packages/drawnix/src/components/comic-creator/ComicCreator.tsx
@@ -57,7 +57,7 @@ import { MessagePlugin } from '../../utils/message-plugin';
 import {
   analytics,
   getPromptAnalyticsSummary,
-} from '../../utils/posthog-analytics';
+} from '../../utils/umami-analytics';
 import { MediaViewer } from '../shared/MediaViewer';
 import {
   WorkflowNavBar,

--- a/packages/drawnix/src/components/knowledge-base/KBKnowledgeExtraction.tsx
+++ b/packages/drawnix/src/components/knowledge-base/KBKnowledgeExtraction.tsx
@@ -47,7 +47,7 @@ import {
   type ModelRef,
 } from '../../utils/settings-manager';
 import { copyToClipboard } from '../../utils/runtime-helpers';
-import { analytics } from '../../utils/posthog-analytics';
+import { analytics } from '../../utils/umami-analytics';
 
 // 默认使用的模型，避免使用 gpt-5.1 导致 500 错误
 const DEFAULT_MODEL = 'gemini-3.1-pro-preview';

--- a/packages/drawnix/src/components/minimap/Minimap.tsx
+++ b/packages/drawnix/src/components/minimap/Minimap.tsx
@@ -22,7 +22,7 @@ import {
 } from '../../types/minimap.types';
 import { ChevronRightIcon } from 'tdesign-icons-react';
 import { Z_INDEX } from '../../constants/z-index';
-import { analytics } from '../../utils/posthog-analytics';
+import { analytics } from '../../utils/umami-analytics';
 import { HoverTip } from '../shared/hover';
 import './minimap.scss';
 

--- a/packages/drawnix/src/components/music-analyzer/pages/CreatePage.tsx
+++ b/packages/drawnix/src/components/music-analyzer/pages/CreatePage.tsx
@@ -46,7 +46,7 @@ import {
   normalizeMusicAnalysisData,
 } from '../../../services/music-analysis-service';
 import { getDefaultAudioModel } from '../../../constants/model-config';
-import { analytics } from '../../../utils/posthog-analytics';
+import { analytics } from '../../../utils/umami-analytics';
 
 const DEFAULT_ANALYSIS_MODEL = 'gemini-2.5-pro';
 const STORAGE_KEY_MODEL = 'music-analyzer:model';

--- a/packages/drawnix/src/components/music-analyzer/pages/GeneratePage.tsx
+++ b/packages/drawnix/src/components/music-analyzer/pages/GeneratePage.tsx
@@ -17,7 +17,7 @@ import {
   readStoredModelSelection,
   writeStoredModelSelection,
 } from '../utils';
-import { analytics } from '../../../utils/posthog-analytics';
+import { analytics } from '../../../utils/umami-analytics';
 
 const STORAGE_KEY_AUDIO_MODEL = 'music-analyzer:audio-model';
 

--- a/packages/drawnix/src/components/music-analyzer/pages/LyricsPage.tsx
+++ b/packages/drawnix/src/components/music-analyzer/pages/LyricsPage.tsx
@@ -34,7 +34,7 @@ import {
   normalizeMusicBrief,
   type MusicBrief,
 } from '../music-brief';
-import { analytics } from '../../../utils/posthog-analytics';
+import { analytics } from '../../../utils/umami-analytics';
 
 const STORAGE_KEY_MODEL = 'music-analyzer:model';
 const DEFAULT_ANALYSIS_MODEL = 'gemini-2.5-pro';

--- a/packages/drawnix/src/components/mv-creator/pages/AnalyzePage.tsx
+++ b/packages/drawnix/src/components/mv-creator/pages/AnalyzePage.tsx
@@ -29,7 +29,7 @@ import {
 } from '../../shared/workflow';
 import { ModelDropdown } from '../../ai-input-bar/ModelDropdown';
 import { KnowledgeNoteContextSelector } from '../../shared';
-import { analytics } from '../../../utils/posthog-analytics';
+import { analytics } from '../../../utils/umami-analytics';
 
 const STORAGE_KEY_VIDEO_MODEL = 'mv-creator:video-model';
 const STORAGE_KEY_STORYBOARD_MODEL = 'mv-creator:storyboard-model';

--- a/packages/drawnix/src/components/mv-creator/pages/GeneratePage.tsx
+++ b/packages/drawnix/src/components/mv-creator/pages/GeneratePage.tsx
@@ -65,7 +65,7 @@ import {
   collectWorkflowExportAssets,
   exportWorkflowAssetsZip,
 } from '../../../utils/workflow-generation-utils';
-import { analytics } from '../../../utils/posthog-analytics';
+import { analytics } from '../../../utils/umami-analytics';
 import { markAssetAsCharacter } from '../../../services/character-asset-metadata-service';
 
 const STORAGE_KEY_IMAGE_MODEL = 'mv-creator:image-model';

--- a/packages/drawnix/src/components/mv-creator/pages/ScriptPage.tsx
+++ b/packages/drawnix/src/components/mv-creator/pages/ScriptPage.tsx
@@ -31,7 +31,7 @@ import { taskQueueService } from '../../../services/task-queue';
 import { TaskType, type KnowledgeContextRef } from '../../../types/task.types';
 import { syncMVRewriteTask } from '../task-sync';
 import { KnowledgeNoteContextSelector } from '../../shared';
-import { analytics } from '../../../utils/posthog-analytics';
+import { analytics } from '../../../utils/umami-analytics';
 
 function autoResize(el: HTMLTextAreaElement) {
   el.style.height = 'auto';

--- a/packages/drawnix/src/components/project-drawer/FramePanel.tsx
+++ b/packages/drawnix/src/components/project-drawer/FramePanel.tsx
@@ -137,7 +137,7 @@ import {
   resolveInvocationRoute,
   type ModelRef,
 } from '../../utils/settings-manager';
-import { analytics } from '../../utils/posthog-analytics';
+import { analytics } from '../../utils/umami-analytics';
 import { IMAGE_GENERATION_TIMEOUT_MS } from '../../constants/TASK_CONSTANTS';
 import type { ModelConfig } from '../../constants/model-config';
 import { AssetType, SelectionMode, type Asset } from '../../types/asset.types';

--- a/packages/drawnix/src/components/project-drawer/ProjectDrawer.tsx
+++ b/packages/drawnix/src/components/project-drawer/ProjectDrawer.tsx
@@ -64,7 +64,7 @@ import {
   PPT_EDITOR_OPEN_EVENT,
   type PPTEditorOpenEventDetail,
 } from '../../services/ppt/ppt-ui-events';
-import { analytics } from '../../utils/posthog-analytics';
+import { analytics } from '../../utils/umami-analytics';
 import './project-drawer.scss';
 
 export interface ProjectDrawerProps {

--- a/packages/drawnix/src/components/prompt-history/PromptHistoryTool.tsx
+++ b/packages/drawnix/src/components/prompt-history/PromptHistoryTool.tsx
@@ -30,7 +30,7 @@ import {
 import {
   analytics,
   type PromptAnalyticsType,
-} from '../../utils/posthog-analytics';
+} from '../../utils/umami-analytics';
 import { copyToClipboard } from '../../utils/runtime-helpers';
 import { RetryImage } from '../retry-image';
 import { HoverTip } from '../shared/hover';

--- a/packages/drawnix/src/components/settings-dialog/settings-dialog.tsx
+++ b/packages/drawnix/src/components/settings-dialog/settings-dialog.tsx
@@ -101,7 +101,7 @@ import { openModelBenchmarkTool } from '../../services/model-benchmark-launcher'
 import {
   analytics,
   getProviderEndpointAnalytics,
-} from '../../utils/posthog-analytics';
+} from '../../utils/umami-analytics';
 import { modelBenchmarkService } from '../../services/model-benchmark-service';
 import { HoverTip } from '../shared/hover';
 import { createProviderProfileDraft } from './provider-profile-draft';

--- a/packages/drawnix/src/components/shared/PromptListPanel.tsx
+++ b/packages/drawnix/src/components/shared/PromptListPanel.tsx
@@ -20,7 +20,7 @@ import {
 import {
   analytics,
   type PromptAnalyticsType,
-} from '../../utils/posthog-analytics';
+} from '../../utils/umami-analytics';
 import './prompt-list-panel.scss';
 
 export interface PromptItem {

--- a/packages/drawnix/src/components/shared/PromptOptimizeDialog.tsx
+++ b/packages/drawnix/src/components/shared/PromptOptimizeDialog.tsx
@@ -43,7 +43,7 @@ import {
 import {
   analytics,
   type PromptAnalyticsType,
-} from '../../utils/posthog-analytics';
+} from '../../utils/umami-analytics';
 import './prompt-optimize-dialog.scss';
 
 type OptimizeHistoryPanel = 'current' | 'requirements';

--- a/packages/drawnix/src/components/task-queue/TaskQueuePanel.tsx
+++ b/packages/drawnix/src/components/task-queue/TaskQueuePanel.tsx
@@ -64,7 +64,7 @@ import {
 } from '../../utils/lyrics-task-utils';
 import { resolveAudioResultUrls } from '../../services/audio-task-result-utils';
 import { ConfirmDialog } from '../dialog/ConfirmDialog';
-import { analytics } from '../../utils/posthog-analytics';
+import { analytics } from '../../utils/umami-analytics';
 import { DRAWER_PIN_KEYS } from '../../utils/drawer-pin';
 import {
   buildImageTaskAIInputPrefillData,

--- a/packages/drawnix/src/components/toolbar/pen-settings-toolbar/pen-settings-toolbar.tsx
+++ b/packages/drawnix/src/components/toolbar/pen-settings-toolbar/pen-settings-toolbar.tsx
@@ -26,7 +26,7 @@ import {
   AnchorSymmetricIcon,
 } from '../../icons';
 import './pen-settings-toolbar.scss';
-import { analytics } from '../../../utils/posthog-analytics';
+import { analytics } from '../../../utils/umami-analytics';
 import { SizePicker } from '../pencil-settings-toolbar/size-picker';
 
 const PEN_WIDTH_PRESETS = [1, 2, 4, 8, 12, 16, 24, 32, 48, 64, 96, 100];

--- a/packages/drawnix/src/components/toolbar/pencil-settings-toolbar/eraser-settings-toolbar.tsx
+++ b/packages/drawnix/src/components/toolbar/pencil-settings-toolbar/eraser-settings-toolbar.tsx
@@ -25,7 +25,7 @@ import { CursorPreview } from './cursor-preview';
 import { SizePicker } from './size-picker';
 import './pencil-settings-toolbar.scss';
 import { HoverTip } from '../../shared/hover';
-import { analytics } from '../../../utils/posthog-analytics';
+import { analytics } from '../../../utils/umami-analytics';
 
 // 预设橡皮擦大小（步长更大，最大256px）
 const ERASER_WIDTH_PRESETS = [16, 32, 48, 64, 96, 128, 192, 256];

--- a/packages/drawnix/src/components/toolbar/pencil-settings-toolbar/pencil-settings-toolbar.tsx
+++ b/packages/drawnix/src/components/toolbar/pencil-settings-toolbar/pencil-settings-toolbar.tsx
@@ -38,7 +38,7 @@ import {
 } from '../../icons';
 import './pencil-settings-toolbar.scss';
 import { HoverTip } from '../../shared/hover';
-import { analytics } from '../../../utils/posthog-analytics';
+import { analytics } from '../../../utils/umami-analytics';
 
 // 模拟光标预览组件
 const CursorPreview: React.FC<{

--- a/packages/drawnix/src/components/toolbox-drawer/ToolWinBoxManager.tsx
+++ b/packages/drawnix/src/components/toolbox-drawer/ToolWinBoxManager.tsx
@@ -28,7 +28,7 @@ import { processToolUrl } from '../../utils/url-template';
 import { useDeviceType } from '../../hooks/useDeviceType';
 import { toolRegistry } from '../../tools/registry';
 import { winboxManagerService } from '../../services/winbox-manager-service';
-import { analytics } from '../../utils/posthog-analytics';
+import { analytics } from '../../utils/umami-analytics';
 
 /**
  * 工具弹窗管理器组件

--- a/packages/drawnix/src/components/toolbox-drawer/ToolboxDrawer.tsx
+++ b/packages/drawnix/src/components/toolbox-drawer/ToolboxDrawer.tsx
@@ -19,7 +19,7 @@ import { useDrawnix } from '../../hooks/use-drawnix';
 import { ToolTransforms } from '../../plugins/with-tool';
 import { toolboxService } from '../../services/toolbox-service';
 import { toolWindowService } from '../../services/tool-window-service';
-import { analytics } from '../../utils/posthog-analytics';
+import { analytics } from '../../utils/umami-analytics';
 import { ToolDefinition } from '../../types/toolbox.types';
 import {
   DEFAULT_TOOL_CONFIG,

--- a/packages/drawnix/src/components/video-analyzer/pages/AnalyzePage.tsx
+++ b/packages/drawnix/src/components/video-analyzer/pages/AnalyzePage.tsx
@@ -56,7 +56,7 @@ import {
 } from '../video-source-cache';
 import { taskQueueService } from '../../../services/task-queue';
 import { syncVideoAnalyzerTask } from '../task-sync';
-import { analytics } from '../../../utils/posthog-analytics';
+import { analytics } from '../../../utils/umami-analytics';
 import { MessagePlugin } from '../../../utils/message-plugin';
 
 type InputMode = 'prompt' | 'upload' | 'youtube';

--- a/packages/drawnix/src/components/video-analyzer/pages/GeneratePage.tsx
+++ b/packages/drawnix/src/components/video-analyzer/pages/GeneratePage.tsx
@@ -70,7 +70,7 @@ import {
   collectWorkflowExportAssets,
   exportWorkflowAssetsZip,
 } from '../../../utils/workflow-generation-utils';
-import { analytics } from '../../../utils/posthog-analytics';
+import { analytics } from '../../../utils/umami-analytics';
 import { markAssetAsCharacter } from '../../../services/character-asset-metadata-service';
 
 const STORAGE_KEY_IMAGE_MODEL = 'video-analyzer:image-model';

--- a/packages/drawnix/src/components/video-analyzer/pages/ScriptPage.tsx
+++ b/packages/drawnix/src/components/video-analyzer/pages/ScriptPage.tsx
@@ -31,7 +31,7 @@ import {
 import { taskQueueService } from '../../../services/task-queue';
 import { TaskType } from '../../../types/task.types';
 import { syncVideoAnalyzerTask } from '../task-sync';
-import { analytics } from '../../../utils/posthog-analytics';
+import { analytics } from '../../../utils/umami-analytics';
 
 /** 自适应高度 textarea 的 onInput 处理 */
 function autoResize(el: HTMLTextAreaElement) {

--- a/packages/drawnix/src/data/audio.ts
+++ b/packages/drawnix/src/data/audio.ts
@@ -6,7 +6,7 @@ import {
   getInsertionPointBelowBottommostElement,
   scrollToPointIfNeeded,
 } from '../utils/selection-utils';
-import { analytics } from '../utils/posthog-analytics';
+import { analytics } from '../utils/umami-analytics';
 import { cacheRemoteUrl } from '../services/media-executor/fallback-utils';
 import { isVirtualMediaUrl } from '../utils/virtual-media-url';
 import { createHash, getAudioCacheKeySeed } from './audio-cache-key';

--- a/packages/drawnix/src/data/image.test.ts
+++ b/packages/drawnix/src/data/image.test.ts
@@ -36,7 +36,7 @@ vi.mock('../services/asset-storage-service', () => ({
   assetStorageService: {},
 }));
 
-vi.mock('../utils/posthog-analytics', () => ({
+vi.mock('../utils/umami-analytics', () => ({
   analytics: {
     track: vi.fn(),
   },

--- a/packages/drawnix/src/data/image.ts
+++ b/packages/drawnix/src/data/image.ts
@@ -19,7 +19,7 @@ import {
 } from '../utils/selection-utils';
 import { assetStorageService } from '../services/asset-storage-service';
 import { unifiedCacheService } from '../services/unified-cache-service';
-import { analytics } from '../utils/posthog-analytics';
+import { analytics } from '../utils/umami-analytics';
 import { cacheRemoteUrl } from '../services/media-executor/fallback-utils';
 import { generateUUID, normalizeImageDataUrl } from '@aitu/utils';
 import { AssetSource, AssetType } from '../types/asset.types';

--- a/packages/drawnix/src/data/video.ts
+++ b/packages/drawnix/src/data/video.ts
@@ -4,7 +4,7 @@ import {
   getInsertionPointBelowBottommostElement,
   scrollToPointIfNeeded,
 } from '../utils/selection-utils';
-import { analytics } from '../utils/posthog-analytics';
+import { analytics } from '../utils/umami-analytics';
 import { getInsertionPointFromSavedSelection } from '../utils/canvas-insertion-layout';
 import { insertImageNodeAtPoint } from './image';
 

--- a/packages/drawnix/src/hooks/useCharacters.ts
+++ b/packages/drawnix/src/hooks/useCharacters.ts
@@ -8,7 +8,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { characterStorageService } from '../services/character-storage-service';
 import { characterAPIService } from '../services/character-api-service';
-import { analytics } from '../utils/posthog-analytics';
+import { analytics } from '../utils/umami-analytics';
 import type {
   SoraCharacter,
   CharacterStatus,

--- a/packages/drawnix/src/index.ts
+++ b/packages/drawnix/src/index.ts
@@ -20,12 +20,8 @@ export type {
   CachedMedia,
   CacheStatus,
 } from './services/unified-cache-service';
-export {
-  analytics,
-  getAnalyticsReleaseContext,
-  registerAnalyticsSuperProperties,
-} from './utils/posthog-analytics';
-export type { AnalyticsReleaseContext } from './utils/posthog-analytics';
+export { analytics, getAnalyticsReleaseContext } from './utils/umami-analytics';
+export type { AnalyticsReleaseContext } from './utils/umami-analytics';
 
 // Export SW channel client
 export { swChannelClient } from './services/sw-channel/client';

--- a/packages/drawnix/src/mcp/tools/ppt-generation.ts
+++ b/packages/drawnix/src/mcp/tools/ppt-generation.ts
@@ -34,7 +34,7 @@ import {
   resolveInvocationPlanFromRoute,
   supportsTextBindingImageInput,
 } from '../../services/provider-routing';
-import { analytics } from '../../utils/posthog-analytics';
+import { analytics } from '../../utils/umami-analytics';
 import {
   type PPTGenerationParams,
   type PPTOutline,

--- a/packages/drawnix/src/plugins/tracking/index.ts
+++ b/packages/drawnix/src/plugins/tracking/index.ts
@@ -11,13 +11,21 @@ export type { TrackingPluginContext } from './withTracking';
 export { useTracking } from './hooks/useTracking';
 
 // Services (for advanced usage)
-export { TrackingService, getTrackingService, resetTrackingService } from '../../services/tracking/tracking-service';
+export {
+  TrackingService,
+  getTrackingService,
+  resetTrackingService,
+} from '../../services/tracking/tracking-service';
 export { TrackingBatchService } from '../../services/tracking/tracking-batch-service';
 export { TrackingStorageService } from '../../services/tracking/tracking-storage-service';
-export { posthogAdapter } from '../../services/tracking/posthog-adapter';
+export { umamiAdapter } from '../../services/tracking/umami-adapter';
 
 // Configuration
-export { DEFAULT_TRACK_CONFIG, getVersion, mergeConfig } from '../../services/tracking/tracking-config';
+export {
+  DEFAULT_TRACK_CONFIG,
+  getVersion,
+  mergeConfig,
+} from '../../services/tracking/tracking-config';
 
 // Types
 export type {

--- a/packages/drawnix/src/services/__tests__/model-benchmark-service.test.ts
+++ b/packages/drawnix/src/services/__tests__/model-benchmark-service.test.ts
@@ -28,7 +28,7 @@ describe('model-benchmark-service', () => {
     vi.doUnmock('../kv-storage-service');
     vi.doUnmock('../utils/gemini-api');
     vi.doUnmock('../utils/settings-manager');
-    vi.doUnmock('../utils/posthog-analytics');
+    vi.doUnmock('../utils/umami-analytics');
     vi.doUnmock('../model-adapters');
   });
 
@@ -109,7 +109,7 @@ describe('model-benchmark-service', () => {
         modelId,
       }),
     }));
-    vi.doMock('../utils/posthog-analytics', () => ({
+    vi.doMock('../utils/umami-analytics', () => ({
       analytics: { track: vi.fn() },
     }));
     vi.doMock('../model-adapters', () => ({

--- a/packages/drawnix/src/services/__tests__/task-queue-service-image-retry.test.ts
+++ b/packages/drawnix/src/services/__tests__/task-queue-service-image-retry.test.ts
@@ -341,7 +341,7 @@ async function setupTaskQueueServiceHarness(statusSequence: TaskStatus[]) {
     };
   });
 
-  vi.doMock('../../utils/posthog-analytics', () => ({
+  vi.doMock('../../utils/umami-analytics', () => ({
     analytics: {
       track: vi.fn(),
       trackModelCall: vi.fn(),

--- a/packages/drawnix/src/services/agent/agent-executor.ts
+++ b/packages/drawnix/src/services/agent/agent-executor.ts
@@ -23,7 +23,7 @@ import {
 } from './system-prompts';
 import { parseToolCalls, extractTextContent } from './tool-parser';
 import { geminiSettings } from '../../utils/settings-manager';
-import { analytics } from '../../utils/posthog-analytics';
+import { analytics } from '../../utils/umami-analytics';
 import {
   getTextBindingMaxImageCount,
   resolveInvocationPlanFromRoute,

--- a/packages/drawnix/src/services/asset-storage-service.ts
+++ b/packages/drawnix/src/services/asset-storage-service.ts
@@ -17,7 +17,7 @@ import {
 } from '../utils/asset-utils';
 import { canAddAssetBySize } from '../utils/storage-quota';
 import { unifiedCacheService } from './unified-cache-service';
-import { analytics } from '../utils/posthog-analytics';
+import { analytics } from '../utils/umami-analytics';
 import type {
   Asset,
   StoredAsset,

--- a/packages/drawnix/src/services/backup-restore/backup-export-service.ts
+++ b/packages/drawnix/src/services/backup-restore/backup-export-service.ts
@@ -20,7 +20,7 @@ import { VERSIONS } from '../../constants';
 import localforage from 'localforage';
 import { ASSET_CONSTANTS } from '../../constants/ASSET_CONSTANTS';
 import { unifiedCacheService } from '../unified-cache-service';
-import { analytics } from '../../utils/posthog-analytics';
+import { analytics } from '../../utils/umami-analytics';
 import { exportAllData as exportKnowledgeBaseData } from '../kb-import-export-service';
 import { APP_DB_NAME, APP_DB_STORES } from '../app-database';
 import { BackupPartManager } from './backup-part-manager';

--- a/packages/drawnix/src/services/backup-restore/backup-import-service.ts
+++ b/packages/drawnix/src/services/backup-restore/backup-import-service.ts
@@ -22,7 +22,7 @@ import localforage from 'localforage';
 import { ASSET_CONSTANTS } from '../../constants/ASSET_CONSTANTS';
 import { unifiedCacheService } from '../unified-cache-service';
 import { assetStorageService } from '../asset-storage-service';
-import { analytics } from '../../utils/posthog-analytics';
+import { analytics } from '../../utils/umami-analytics';
 import { importAllData as importKnowledgeBaseData } from '../kb-import-export-service';
 import { _getStoreInstances } from '../knowledge-base-service';
 import { taskStorageWriter, type SWTask } from '../media-executor/task-storage-writer';

--- a/packages/drawnix/src/services/chat-service.ts
+++ b/packages/drawnix/src/services/chat-service.ts
@@ -15,7 +15,7 @@ import {
 } from '../utils/gemini-api/message-utils';
 import type { Attachment, ChatMessage, StreamEvent } from '../types/chat.types';
 import { MessageRole } from '../types/chat.types';
-import { analytics } from '../utils/posthog-analytics';
+import { analytics } from '../utils/umami-analytics';
 import type { ModelRef } from '../utils/settings-manager';
 import {
   getTextBindingMaxImageCount,

--- a/packages/drawnix/src/services/generation-api-service.ts
+++ b/packages/drawnix/src/services/generation-api-service.ts
@@ -18,7 +18,7 @@ import {
 } from './audio-api-service';
 import { videoAPIService } from './video-api-service';
 import { TASK_TIMEOUT } from '../constants/TASK_CONSTANTS';
-import { analytics } from '../utils/posthog-analytics';
+import { analytics } from '../utils/umami-analytics';
 import { legacyTaskQueueService as taskQueueService } from './task-queue';
 import { unifiedCacheService } from './unified-cache-service';
 import { convertAspectRatioToSize } from '../constants/image-aspect-ratios';

--- a/packages/drawnix/src/services/model-benchmark-service.ts
+++ b/packages/drawnix/src/services/model-benchmark-service.ts
@@ -6,7 +6,7 @@ import type { ModelVendor } from '../constants/model-config';
 import { kvStorageService } from './kv-storage-service';
 import { generateTaskId } from '../utils/task-utils';
 import { createModelRef } from '../utils/settings-manager';
-import { analytics } from '../utils/posthog-analytics';
+import { analytics } from '../utils/umami-analytics';
 import {
   getAdapterContextFromSettings,
   resolveAdapterForInvocation,

--- a/packages/drawnix/src/services/page-report-service.ts
+++ b/packages/drawnix/src/services/page-report-service.ts
@@ -1,41 +1,20 @@
 /**
  * Page Report Monitoring Service
  *
- * Monitors page view events and performance metrics:
- * - Page views (URL changes, SPA navigation)
+ * Monitors page lifecycle and performance metrics:
+ * - Umami owns standard page views
  * - Page load time and performance
- * - User session data
- * - Device and browser information
+ * - Visibility and unload events
  */
 
-import { analytics } from '../utils/posthog-analytics';
+import { analytics } from '../utils/umami-analytics';
 
 /**
  * Page report event category
  */
 const PAGE_REPORT_CATEGORY = 'page_report';
-const APP_PAGE_VIEW_EVENT = 'app_page_view';
 
 let pageReportInitialized = false;
-let lastTrackedHref = '';
-
-/**
- * Page view data interface
- */
-interface PageViewData {
-  page_url: string;
-  page_path: string;
-  page_title: string;
-  referrer: string;
-  viewport_width: number;
-  viewport_height: number;
-  screen_width: number;
-  screen_height: number;
-  device_type: 'mobile' | 'tablet' | 'desktop';
-  user_agent: string;
-  language: string;
-  timestamp: number;
-}
 
 /**
  * Page performance data interface
@@ -44,56 +23,18 @@ interface PagePerformanceData {
   page_url: string;
   page_path: string;
   // Navigation Timing API metrics
-  dns_time?: number;           // DNS lookup time
-  tcp_time?: number;           // TCP connection time
-  request_time?: number;       // Request time
-  response_time?: number;      // Response time
-  dom_processing_time?: number;// DOM processing time
-  dom_interactive_time?: number;// DOM interactive time
-  dom_complete_time?: number;  // DOM complete time
-  load_time?: number;          // Total page load time
+  dns_time?: number; // DNS lookup time
+  tcp_time?: number; // TCP connection time
+  request_time?: number; // Request time
+  response_time?: number; // Response time
+  dom_processing_time?: number; // DOM processing time
+  dom_interactive_time?: number; // DOM interactive time
+  dom_complete_time?: number; // DOM complete time
+  load_time?: number; // Total page load time
   // Resource Timing
   total_resources?: number;
-  total_size?: number;         // Total resource size in bytes
+  total_size?: number; // Total resource size in bytes
   timestamp: number;
-}
-
-/**
- * Get device type based on screen width
- */
-function getDeviceType(): 'mobile' | 'tablet' | 'desktop' {
-  const width = window.innerWidth;
-  if (width < 768) {
-    return 'mobile';
-  } else if (width < 1024) {
-    return 'tablet';
-  } else {
-    return 'desktop';
-  }
-}
-
-/** 上报字段最大长度，控制 payload 体积避免 413 */
-const MAX_STRING_LENGTH = 200;
-
-/**
- * Collect page view data (user_agent 截断以减小请求体)
- */
-function collectPageViewData(): PageViewData {
-  const ua = navigator.userAgent;
-  return {
-    page_url: window.location.href,
-    page_path: window.location.pathname,
-    page_title: document.title,
-    referrer: document.referrer,
-    viewport_width: window.innerWidth,
-    viewport_height: window.innerHeight,
-    screen_width: window.screen.width,
-    screen_height: window.screen.height,
-    device_type: getDeviceType(),
-    user_agent: ua.length > MAX_STRING_LENGTH ? ua.slice(0, MAX_STRING_LENGTH) : ua,
-    language: navigator.language,
-    timestamp: Date.now(),
-  };
 }
 
 /**
@@ -113,7 +54,9 @@ function collectPagePerformanceData(): PagePerformanceData | null {
 
   // Use modern Performance Navigation Timing API (Level 2) if available
   if (window.performance.getEntriesByType) {
-    const navEntries = window.performance.getEntriesByType('navigation') as PerformanceNavigationTiming[];
+    const navEntries = window.performance.getEntriesByType(
+      'navigation'
+    ) as PerformanceNavigationTiming[];
 
     if (navEntries && navEntries.length > 0) {
       const navEntry = navEntries[0];
@@ -140,12 +83,14 @@ function collectPagePerformanceData(): PagePerformanceData | null {
 
       // DOM processing time
       if (navEntry.domComplete && navEntry.domInteractive) {
-        data.dom_processing_time = navEntry.domComplete - navEntry.domInteractive;
+        data.dom_processing_time =
+          navEntry.domComplete - navEntry.domInteractive;
       }
 
       // DOM interactive time
       if (navEntry.domInteractive && navEntry.fetchStart) {
-        data.dom_interactive_time = navEntry.domInteractive - navEntry.fetchStart;
+        data.dom_interactive_time =
+          navEntry.domInteractive - navEntry.fetchStart;
       }
 
       // DOM complete time
@@ -175,41 +120,12 @@ function collectPagePerformanceData(): PagePerformanceData | null {
 }
 
 /**
- * Track page view event
- */
-export function trackPageView(): void {
-  if (!analytics.isAnalyticsEnabled()) {
-    // console.debug('[Page Report] PostHog not available, skipping page view');
-    return;
-  }
-
-  const pageViewData = collectPageViewData();
-
-  if (pageViewData.page_url === lastTrackedHref) {
-    return;
-  }
-
-  lastTrackedHref = pageViewData.page_url;
-
-  analytics.track(APP_PAGE_VIEW_EVENT, {
-    category: PAGE_REPORT_CATEGORY,
-    ...pageViewData,
-  });
-
-  // console.log('[Page Report] Page view tracked:', {
-  //   path: pageViewData.page_path,
-  //   title: pageViewData.page_title,
-  //   device: pageViewData.device_type,
-  // });
-}
-
-/**
  * Track page performance event
  * Should be called after page load is complete
  */
 export function trackPagePerformance(): void {
   if (!analytics.isAnalyticsEnabled()) {
-    // console.debug('[Page Report] PostHog not available, skipping performance');
+    // console.debug('[Page Report] Umami not available, skipping performance');
     return;
   }
 
@@ -261,9 +177,6 @@ export function initPageReport(): void {
     }
     pageReportInitialized = true;
 
-    // Track initial page view
-    trackPageView();
-
     // Track page performance after load
     if (document.readyState === 'complete') {
       // Page already loaded
@@ -301,25 +214,6 @@ export function initPageReport(): void {
         });
       }
     });
-
-    // Track SPA navigation (for single-page applications)
-    // Listen to popstate for browser back/forward
-    window.addEventListener('popstate', () => {
-      setTimeout(() => {
-        trackPageView();
-      }, 100); // Small delay to ensure URL has changed
-    });
-
-    // Intercept pushState for explicit SPA navigation.
-    // replaceState is often used for transient URL cleanup and should not count as a page view.
-    const originalPushState = history.pushState;
-
-    history.pushState = function (...args) {
-      originalPushState.apply(this, args);
-      setTimeout(() => {
-        trackPageView();
-      }, 100);
-    };
 
     // console.log('[Page Report] Monitoring initialized successfully');
   } catch (error) {

--- a/packages/drawnix/src/services/ppt/mindmap-to-ppt.ts
+++ b/packages/drawnix/src/services/ppt/mindmap-to-ppt.ts
@@ -36,7 +36,7 @@ import {
   getPPTFrameGridPositions,
   loadPPTFrameLayoutColumns,
 } from './ppt-frame-layout';
-import { analytics } from '../../utils/posthog-analytics';
+import { analytics } from '../../utils/umami-analytics';
 
 /**
  * 从 MindElement 的 data 中提取纯文本

--- a/packages/drawnix/src/services/task-queue-service.ts
+++ b/packages/drawnix/src/services/task-queue-service.ts
@@ -30,7 +30,7 @@ import { taskStorageReader } from './task-storage-reader';
 import { executorFactory, waitForTaskCompletion } from './media-executor';
 import { hasInvocationRouteCredentials } from '../utils/settings-manager';
 import { DEFAULT_AUDIO_MODEL_ID } from '../constants/model-config';
-import { analytics } from '../utils/posthog-analytics';
+import { analytics } from '../utils/umami-analytics';
 import {
   getAdapterContextFromSettings,
   resolveAdapterForInvocation,

--- a/packages/drawnix/src/services/tool-window-service.ts
+++ b/packages/drawnix/src/services/tool-window-service.ts
@@ -12,7 +12,7 @@ import {
   ToolWindowLaunchMode,
   ToolWindowState,
 } from '../types/toolbox.types';
-import { analytics } from '../utils/posthog-analytics';
+import { analytics } from '../utils/umami-analytics';
 import { toolRegistry } from '../tools/registry';
 
 /** localStorage key for pinned tools */

--- a/packages/drawnix/src/services/tracking/tracking-batch-service.ts
+++ b/packages/drawnix/src/services/tracking/tracking-batch-service.ts
@@ -5,7 +5,7 @@
  */
 
 import type { TrackEvent, BatchConfig } from '../../types/tracking.types';
-import { posthogAdapter } from './posthog-adapter';
+import { umamiAdapter } from './umami-adapter';
 
 /**
  * Batch Upload Service
@@ -77,16 +77,20 @@ export class TrackingBatchService {
     this.queue = [];
 
     try {
-      // Upload batch using PostHog adapter
-      const results = await posthogAdapter.trackBatch(eventsToUpload);
+      // Upload batch using Umami adapter
+      const results = await umamiAdapter.trackBatch(eventsToUpload);
 
       // Check for failures
-      const failures = results.filter(r => !r.success);
+      const failures = results.filter((r) => !r.success);
       if (failures.length > 0) {
-        console.error(`Batch upload: ${failures.length}/${eventsToUpload.length} events failed`);
+        console.error(
+          `Batch upload: ${failures.length}/${eventsToUpload.length} events failed`
+        );
 
         // Re-queue failed events for retry
-        const failedEvents = eventsToUpload.filter((_, index) => !results[index].success);
+        const failedEvents = eventsToUpload.filter(
+          (_, index) => !results[index].success
+        );
         this.requeueFailedEvents(failedEvents);
       }
     } catch (error) {
@@ -104,7 +108,7 @@ export class TrackingBatchService {
    */
   private async uploadImmediate(event: TrackEvent): Promise<void> {
     try {
-      await posthogAdapter.track(event);
+      await umamiAdapter.track(event);
     } catch (error) {
       console.error('Immediate upload failed:', error);
     }
@@ -167,7 +171,7 @@ export class TrackingBatchService {
     }
 
     // Use navigator.sendBeacon for reliable page unload tracking
-    // Note: PostHog SDK should handle sendBeacon internally
+    // The Umami SDK handles its own transport; flush queued events before unload.
     this.flush();
   }
 }

--- a/packages/drawnix/src/services/tracking/umami-adapter.ts
+++ b/packages/drawnix/src/services/tracking/umami-adapter.ts
@@ -1,19 +1,19 @@
 /**
- * PostHog Analytics Adapter
+ * Umami Analytics Adapter
  * Feature: 005-declarative-tracking
- * Purpose: Adapter to use existing PostHogAnalytics utility for declarative tracking
+ * Purpose: Adapter to use existing UmamiAnalytics utility for declarative tracking
  */
 
 import type { TrackEvent } from '../../types/tracking.types';
-import { analytics } from '../../utils/posthog-analytics';
+import { analytics } from '../../utils/umami-analytics';
 
 /**
- * PostHog Tracking Adapter
- * Uses existing PostHogAnalytics singleton to avoid code duplication
+ * Umami Tracking Adapter
+ * Uses existing UmamiAnalytics singleton to avoid code duplication
  */
-export class PostHogTrackingAdapter {
+export class UmamiTrackingAdapter {
   /**
-   * Check if PostHog SDK is available
+   * Check if Umami SDK is available
    */
   isAvailable(): boolean {
     return analytics.isAnalyticsEnabled();
@@ -22,11 +22,11 @@ export class PostHogTrackingAdapter {
   /**
    * Track event using existing analytics utility
    * @param event - Tracking event to upload
-   * Note: Silently returns if PostHog SDK is not loaded (consistent with posthog-analytics.ts)
+   * Note: Silently returns if Umami SDK is not loaded (consistent with umami-analytics.ts)
    */
   async track(event: TrackEvent): Promise<void> {
     if (!this.isAvailable()) {
-      // PostHog SDK not loaded, silently skip (e.g., local development)
+      // Umami SDK not loaded, silently skip (e.g., local development)
       return;
     }
 
@@ -46,10 +46,10 @@ export class PostHogTrackingAdapter {
     }
 
     try {
-      // Use existing analytics.track() method
-      analytics.track(event.eventName, enrichedData);
+      // Use existing analytics.track() method and await SDK promises when available.
+      await analytics.track(event.eventName, enrichedData);
     } catch (error) {
-      console.error('[Tracking] PostHog track failed:', error);
+      console.error('[Tracking] Umami track failed:', error);
       throw error; // Re-throw for retry handling
     }
   }
@@ -59,7 +59,9 @@ export class PostHogTrackingAdapter {
    * @param events - Array of tracking events
    * @returns Array of results (success or error)
    */
-  async trackBatch(events: TrackEvent[]): Promise<Array<{ success: boolean; error?: Error }>> {
+  async trackBatch(
+    events: TrackEvent[]
+  ): Promise<Array<{ success: boolean; error?: Error }>> {
     const results: Array<{ success: boolean; error?: Error }> = [];
 
     for (const event of events) {
@@ -75,12 +77,12 @@ export class PostHogTrackingAdapter {
   }
 
   /**
-   * Get PostHog SDK version info (if available)
+   * Get Umami SDK version info (if available)
    */
   getSDKInfo(): { available: boolean; version?: string } {
     return {
       available: this.isAvailable(),
-      version: this.isAvailable() ? 'PostHog JS' : undefined,
+      version: this.isAvailable() ? 'Umami JS' : undefined,
     };
   }
 }
@@ -88,4 +90,4 @@ export class PostHogTrackingAdapter {
 /**
  * Singleton instance
  */
-export const posthogAdapter = new PostHogTrackingAdapter();
+export const umamiAdapter = new UmamiTrackingAdapter();

--- a/packages/drawnix/src/services/web-vitals-service.ts
+++ b/packages/drawnix/src/services/web-vitals-service.ts
@@ -1,7 +1,7 @@
 /**
  * Web Vitals Monitoring Service
  *
- * Monitors Core Web Vitals metrics and reports them to PostHog:
+ * Monitors Core Web Vitals metrics and reports them to Umami:
  * - LCP (Largest Contentful Paint): Loading performance
  * - FID (First Input Delay): Interactivity
  * - CLS (Cumulative Layout Shift): Visual stability
@@ -11,18 +11,18 @@
  */
 
 import type { Metric } from 'web-vitals';
-import { analytics } from '../utils/posthog-analytics';
+import { analytics } from '../utils/umami-analytics';
 
 /**
- * Report Web Vitals metric to PostHog
+ * Report Web Vitals metric to Umami
  *
- * PostHog expects $web_vitals event with specific property names:
+ * The event keeps the existing $web_vitals property names for dashboard compatibility:
  * - $web_vitals_<METRIC>_value: numeric value
  * - $web_vitals_<METRIC>_event: event details object
  */
 function reportWebVitals(metric: Metric): void {
   if (!analytics.isAnalyticsEnabled()) {
-    // console.debug('[Web Vitals] PostHog not available, skipping metric:', metric.name);
+    // console.debug('[Web Vitals] Umami not available, skipping metric:', metric.name);
     return;
   }
 
@@ -53,7 +53,10 @@ function reportWebVitals(metric: Metric): void {
  * Get metric rating based on Web Vitals thresholds
  * Thresholds from: https://web.dev/articles/vitals
  */
-function getMetricRating(name: string, value: number): 'good' | 'needs-improvement' | 'poor' {
+function getMetricRating(
+  name: string,
+  value: number
+): 'good' | 'needs-improvement' | 'poor' {
   const thresholds: Record<string, { good: number; poor: number }> = {
     // LCP: < 2.5s (good), < 4s (needs improvement), >= 4s (poor)
     LCP: { good: 2500, poor: 4000 },
@@ -94,11 +97,11 @@ export async function initWebVitals(): Promise<void> {
     const { onCLS, onFCP, onLCP, onTTFB, onINP } = webVitals;
 
     // Monitor all Core Web Vitals
-    onCLS(reportWebVitals);  // Cumulative Layout Shift
-    onFCP(reportWebVitals);  // First Contentful Paint
-    onLCP(reportWebVitals);  // Largest Contentful Paint
+    onCLS(reportWebVitals); // Cumulative Layout Shift
+    onFCP(reportWebVitals); // First Contentful Paint
+    onLCP(reportWebVitals); // Largest Contentful Paint
     onTTFB(reportWebVitals); // Time to First Byte
-    onINP(reportWebVitals);  // Interaction to Next Paint (replaces FID)
+    onINP(reportWebVitals); // Interaction to Next Paint (replaces FID)
 
     // console.log('[Web Vitals] Monitoring initialized successfully');
   } catch (error) {

--- a/packages/drawnix/src/utils/gemini-api/apiCalls.test.ts
+++ b/packages/drawnix/src/utils/gemini-api/apiCalls.test.ts
@@ -26,7 +26,7 @@ vi.mock('../../services/provider-routing', () => ({
   readProviderResponseText: (response: Response) => response.text(),
 }));
 
-vi.mock('../posthog-analytics', () => ({
+vi.mock('../umami-analytics', () => ({
   analytics: analyticsMock,
   getProviderEndpointAnalytics: (baseUrl?: string | null) => {
     if (!baseUrl) return null;

--- a/packages/drawnix/src/utils/gemini-api/apiCalls.ts
+++ b/packages/drawnix/src/utils/gemini-api/apiCalls.ts
@@ -17,7 +17,7 @@ import {
   VideoGenerationOptions,
 } from './types';
 import { VIDEO_DEFAULT_CONFIG } from './config';
-import { analytics, getProviderEndpointAnalytics } from '../posthog-analytics';
+import { analytics, getProviderEndpointAnalytics } from '../umami-analytics';
 import { IMAGE_GENERATION_TIMEOUT_MS } from '../../constants/TASK_CONSTANTS';
 import {
   buildManualHttpRequestPayload,

--- a/packages/drawnix/src/utils/umami-analytics.test.ts
+++ b/packages/drawnix/src/utils/umami-analytics.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { analytics } from './umami-analytics';
+
+describe('Umami analytics', () => {
+  const trackMock = vi.fn();
+
+  beforeEach(() => {
+    trackMock.mockReset();
+    window.umami = { track: trackMock };
+    window.history.replaceState({}, '', '/analytics-test');
+  });
+
+  afterEach(() => {
+    delete window.umami;
+  });
+
+  it('sends sanitized events with release context', async () => {
+    await analytics.track('test_event', { value: 'ok' });
+
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    expect(trackMock).toHaveBeenCalledWith(
+      'test_event',
+      expect.objectContaining({
+        value: 'ok',
+        hostname: 'localhost',
+        route_name: '/analytics-test',
+      })
+    );
+  });
+
+  it('does not throw when the SDK is unavailable', async () => {
+    delete window.umami;
+
+    await expect(analytics.track('ignored_event')).resolves.toBeUndefined();
+    expect(trackMock).not.toHaveBeenCalled();
+  });
+
+  it('waits for an async Umami SDK result', async () => {
+    let resolveTrack: (() => void) | undefined;
+    trackMock.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveTrack = resolve;
+      })
+    );
+
+    const pending = analytics.track('async_event');
+    await vi.waitFor(() => expect(trackMock).toHaveBeenCalledTimes(1));
+    expect(resolveTrack).toBeDefined();
+    resolveTrack?.();
+    await expect(pending).resolves.toBeUndefined();
+  });
+
+  it('swallows SDK rejections so analytics never breaks the caller', async () => {
+    trackMock.mockRejectedValue(new Error('network unavailable'));
+
+    await expect(analytics.track('rejected_event')).resolves.toBeUndefined();
+  });
+
+  it('handles a burst of events without dropping calls', async () => {
+    trackMock.mockResolvedValue(undefined);
+
+    await Promise.all(
+      Array.from({ length: 100 }, (_, index) =>
+        analytics.track('burst_event', { sequence: index + 1 })
+      )
+    );
+
+    expect(trackMock).toHaveBeenCalledTimes(100);
+  });
+});

--- a/packages/drawnix/src/utils/umami-analytics.test.ts
+++ b/packages/drawnix/src/utils/umami-analytics.test.ts
@@ -1,5 +1,13 @@
+import { readFileSync } from 'node:fs';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { analytics } from './umami-analytics';
+
+const umamiEntryFiles = [
+  '../../../../apps/web/index.html',
+  '../../../../apps/web/public/home.html',
+  '../../../../apps/web/public/en/home.html',
+];
 
 describe('Umami analytics', () => {
   const trackMock = vi.fn();
@@ -67,4 +75,16 @@ describe('Umami analytics', () => {
 
     expect(trackMock).toHaveBeenCalledTimes(100);
   });
+
+  it.each(umamiEntryFiles)(
+    'does not include URL query parameters in automatic pageviews from %s',
+    (entryFile) => {
+      const source = readFileSync(new URL(entryFile, import.meta.url), 'utf8');
+
+      expect(source).toContain(
+        'script.dataset.websiteId = "e6bd249e-bc68-4857-b6a5-02131b4ea286";'
+      );
+      expect(source).toContain('script.dataset.excludeSearch = "true";');
+    }
+  );
 });

--- a/packages/drawnix/src/utils/umami-analytics.ts
+++ b/packages/drawnix/src/utils/umami-analytics.ts
@@ -1,10 +1,10 @@
 /**
- * PostHog Analytics Utility
+ * Umami Analytics Utility
  *
- * Provides type-safe event tracking for PostHog analytics.
+ * Provides type-safe event tracking for Umami analytics.
  * Tracks model calls and API usage.
  *
- * SECURITY: All event data is sanitized before being sent to PostHog
+ * SECURITY: All event data is sanitized before being sent to Umami
  * to prevent accidental leakage of API keys and other sensitive information.
  */
 
@@ -25,9 +25,11 @@ export interface AnalyticsReleaseContext {
 
 declare global {
   interface Window {
-    posthog?: {
-      capture: (eventName: string, properties?: Record<string, any>) => void;
-      register?: (properties: Record<string, any>) => void;
+    umami?: {
+      track: (
+        eventName: string,
+        properties?: Record<string, any>
+      ) => void | Promise<void>;
     };
   }
 }
@@ -219,23 +221,6 @@ function getCommonEventProperties(): AnalyticsEventData {
   return getAnalyticsReleaseContext();
 }
 
-export function registerAnalyticsSuperProperties(
-  properties?: Partial<AnalyticsReleaseContext>
-): void {
-  if (typeof window === 'undefined' || !window.posthog?.register) {
-    return;
-  }
-
-  try {
-    window.posthog.register({
-      ...getAnalyticsReleaseContext(),
-      ...(properties || {}),
-    });
-  } catch (error) {
-    void error;
-  }
-}
-
 function buildAICompatProperties(params: {
   taskId: string;
   taskType: 'image' | 'video' | 'audio' | 'chat';
@@ -258,57 +243,66 @@ function buildAICompatProperties(params: {
 }
 
 /** Analytics utility class */
-class PostHogAnalytics {
+class UmamiAnalytics {
   /**
    * Track a custom event (旁路：脱敏与上报在空闲时执行，不阻塞主流程)
-   * SECURITY: Event data is sanitized before being sent to PostHog
+   * SECURITY: Event data is sanitized before being sent to Umami
    */
-  track(eventName: string, eventData?: Record<string, any>): void {
-    if (typeof window === 'undefined' || !window.posthog) {
+  async track(
+    eventName: string,
+    eventData?: Record<string, any>
+  ): Promise<void> {
+    if (typeof window === 'undefined' || !window.umami) {
       return;
     }
-    const doTrack = (): void => {
-      try {
-        const payload = {
-          ...getCommonEventProperties(),
-          ...(eventData || {}),
-        };
-        const sanitizedData =
-          Object.keys(payload).length > 0
-            ? (sanitizeObject(payload) as Record<string, any>)
-            : undefined;
-        window.posthog!.capture(eventName, sanitizedData);
-      } catch (error) {
-        void error;
+
+    await new Promise<void>((resolve) => {
+      const doTrack = (): void => {
+        resolve();
+      };
+
+      if (
+        typeof (
+          globalThis as unknown as Window & {
+            requestIdleCallback?: (
+              cb: () => void,
+              opts?: { timeout: number }
+            ) => number;
+          }
+        ).requestIdleCallback === 'function'
+      ) {
+        (
+          globalThis as unknown as Window & {
+            requestIdleCallback: (
+              cb: () => void,
+              opts?: { timeout: number }
+            ) => number;
+          }
+        ).requestIdleCallback(doTrack, { timeout: 2000 });
+      } else {
+        setTimeout(doTrack, 0);
       }
-    };
-    if (
-      typeof (
-        globalThis as unknown as Window & {
-          requestIdleCallback?: (
-            cb: () => void,
-            opts?: { timeout: number }
-          ) => number;
-        }
-      ).requestIdleCallback === 'function'
-    ) {
-      (
-        globalThis as unknown as Window & {
-          requestIdleCallback: (
-            cb: () => void,
-            opts?: { timeout: number }
-          ) => number;
-        }
-      ).requestIdleCallback(doTrack, { timeout: 2000 });
-    } else {
-      setTimeout(doTrack, 0);
+    });
+
+    try {
+      const payload = {
+        ...getCommonEventProperties(),
+        ...(eventData || {}),
+      };
+      const sanitizedData =
+        Object.keys(payload).length > 0
+          ? (sanitizeObject(payload) as Record<string, any>)
+          : undefined;
+      await window.umami.track(eventName, sanitizedData);
+    } catch (error) {
+      void error;
     }
   }
 
   /** Track low-frequency UI interactions without adding one-off event names. */
   trackUIInteraction(params: UIInteractionEventParams): void {
     const { metadata, ...coreParams } = params;
-    this.track('ui_interaction', {
+    void this.track('ui_interaction', {
       category: AnalyticsCategory.UI_INTERACTION,
       ...coreParams,
       metadata: metadata || undefined,
@@ -334,7 +328,7 @@ class PostHogAnalytics {
     metadata?: Record<string, any>;
   }): void {
     const { prompt, metadata, ...coreParams } = params;
-    this.track('ppt_action', {
+    void this.track('ppt_action', {
       category: AnalyticsCategory.PPT,
       ...coreParams,
       ...(prompt !== undefined ? getPromptAnalyticsSummary(prompt) : {}),
@@ -365,7 +359,7 @@ class PostHogAnalytics {
       requirements !== undefined
         ? getPromptAnalyticsSummary(requirements)
         : undefined;
-    this.track('prompt_action', {
+    void this.track('prompt_action', {
       category: AnalyticsCategory.PROMPT,
       ...coreParams,
       ...(promptSummary || {}),
@@ -385,7 +379,7 @@ class PostHogAnalytics {
 
   /** Check if analytics is enabled */
   isAnalyticsEnabled(): boolean {
-    return typeof window !== 'undefined' && !!window.posthog;
+    return typeof window !== 'undefined' && !!window.umami;
   }
 
   /** Track AI generation event */
@@ -393,7 +387,7 @@ class PostHogAnalytics {
     event: AIGenerationEvent,
     data: Record<string, any>
   ): void {
-    this.track(event, {
+    void this.track(event, {
       category: AnalyticsCategory.AI_GENERATION,
       ...data,
       timestamp: Date.now(),
@@ -439,7 +433,7 @@ class PostHogAnalytics {
       chat: AIGenerationEvent.CHAT_GENERATION_SUCCESS,
     };
     this.trackAIGeneration(eventMap[params.taskType], params);
-    this.track(
+    void this.track(
       '$ai_generation',
       buildAICompatProperties({
         taskId: params.taskId,
@@ -466,7 +460,7 @@ class PostHogAnalytics {
       chat: AIGenerationEvent.CHAT_GENERATION_FAILED,
     };
     this.trackAIGeneration(eventMap[params.taskType], params);
-    this.track(
+    void this.track(
       '$ai_generation',
       buildAICompatProperties({
         taskId: params.taskId,
@@ -497,7 +491,7 @@ class PostHogAnalytics {
       stream: boolean;
     } & Record<string, unknown>
   ): void {
-    this.track(APICallEvent.API_CALL_START, {
+    void this.track(APICallEvent.API_CALL_START, {
       category: AnalyticsCategory.SYSTEM,
       ...params,
       timestamp: Date.now(),
@@ -514,7 +508,7 @@ class PostHogAnalytics {
       stream: boolean;
     } & Record<string, unknown>
   ): void {
-    this.track(APICallEvent.API_CALL_SUCCESS, {
+    void this.track(APICallEvent.API_CALL_SUCCESS, {
       category: AnalyticsCategory.SYSTEM,
       ...params,
       timestamp: Date.now(),
@@ -532,7 +526,7 @@ class PostHogAnalytics {
       stream: boolean;
     } & Record<string, unknown>
   ): void {
-    this.track(APICallEvent.API_CALL_FAILED, {
+    void this.track(APICallEvent.API_CALL_FAILED, {
       category: AnalyticsCategory.SYSTEM,
       ...params,
       timestamp: Date.now(),
@@ -546,7 +540,7 @@ class PostHogAnalytics {
     attempt: number;
     reason: string;
   }): void {
-    this.track(APICallEvent.API_CALL_RETRY, {
+    void this.track(APICallEvent.API_CALL_RETRY, {
       category: AnalyticsCategory.SYSTEM,
       ...params,
       timestamp: Date.now(),
@@ -555,4 +549,4 @@ class PostHogAnalytics {
 }
 
 // Export singleton instance
-export const analytics = new PostHogAnalytics();
+export const analytics = new UmamiAnalytics();


### PR DESCRIPTION
## 背景

PostHog 统计服务即将产生费用。本次变更将 OpenTu 的前端统计上报从 PostHog 迁移到 Umami，目标是保留现有业务事件和脱敏边界，同时移除 PostHog SDK、配置和运行时依赖。

## 变更内容

- Web 主入口、中文首页、英文首页接入 `https://umami.tu-zi.com/script.js`，使用 website ID `e6bd249e-bc68-4857-b6a5-02131b4ea286`。
- `posthog-analytics.ts` 和 `posthog-adapter.ts` 迁移为 Umami 实现，业务调用方统一改用 `window.umami.track()`。
- 保留现有 AI 生成、API 调用、PPT、Prompt、UI interaction、页面性能、Web Vitals、可见性和卸载事件；事件名、脱敏逻辑、版本/环境/路由上下文保持兼容。
- 删除 PostHog 初始化、`register()` 超级属性、启动轮询、手动重复 pageview、PostHog CSP/SW 放行和异常过滤。
- 标准 pageview 改由 Umami SDK 自动处理，避免 `app_page_view` 与 SDK pageview 重复。
- Umami 未加载、网络失败或 SDK Promise reject 时静默降级，不阻塞应用启动和业务调用。
- 本地开发默认不启用统计，访问 URL 增加 `report=1` 才启用，便于验证。
- 新增 OpenSpec 变更说明和 Umami 专项测试。

## 验证结果

通过：

- Umami 专项及受影响回归测试：5 个测试文件、51 个用例通过；已连续执行 5 轮。
- Umami SDK 异步成功、SDK 缺失、Promise reject、100 条 burst 事件场景均通过。
- 真实 Umami 接收端压测：1000 条混合事件、并发 50，1000/1000 HTTP 200；P50 169ms、P95 563ms、P99 639ms。
- Umami 脚本真实 HTTP 检查：HTTP 200，`application/javascript`，4655 bytes。
- `pnpm nx run drawnix:typecheck` 通过。
- `pnpm nx run web:typecheck` 通过。
- `pnpm nx build web` 通过，包含 Web production build 和 Service Worker build。
- `git diff --check` 通过。
- 运行时代码、配置和构建产物未发现 PostHog 引用。
- 内置浏览器页面可启动且无页面错误，可看到 Umami script 标签，未看到 PostHog script。

当前验证限制：

- 当前内置浏览器会加载 Umami 标签但不执行该第三方脚本，因此没有在该环境拿到 `window.umami.track` 初始化和浏览器网络面板请求证据。需要在预发布/真实 Chrome 环境补做一次 pageview、自定义事件、Web Vitals、无 PostHog 请求和 Umami 故障降级验证。
- 全量 `pnpm nx run drawnix:test` 当前为 193/202 测试文件通过、1717/1774 用例通过，8 个文件/56 个用例失败并有 1 个既有未处理 mock 错误，集中在 AI 输入解析、工作流导出、IndexedDB/jsdom 存储环境和既有 mock；迁移专项全部通过，不能将全量结果写成全绿。
- 本环境没有 `openspec` CLI，未声称 OpenSpec CLI 校验通过。

## 合并前发布检查

1. 部署该分支预览环境。
2. 使用真实 Chrome 打开 `?report=1` 页面，确认 Umami script 返回 200、`window.umami.track` 存在。
3. 在网络面板确认至少有自动 pageview、一个自定义事件和 Web Vitals 请求，且没有任何 PostHog 请求。
4. 暂时阻断 `umami.tu-zi.com`，确认应用仍能启动、交互和生成流程不受阻塞。
5. 合并后观察 Umami 事件量、错误率和页面启动错误至少 24 小时。

## 回滚

若 Umami 接收异常、事件量明显下降或影响启动，直接回滚提交 `85e716cf`，恢复上一版 PostHog 统计实现，并重新部署上一版产物。

## 关联文件

- `openspec/changes/replace-posthog-with-umami-analytics/proposal.md`
- `openspec/changes/replace-posthog-with-umami-analytics/design.md`
- `openspec/changes/replace-posthog-with-umami-analytics/tasks.md`
- `packages/drawnix/src/utils/umami-analytics.test.ts`