### PR TITLE
fix: preserve generated image dimensions and canvas rendering

### DIFF
--- a/packages/drawnix/src/data/image.ts
+++ b/packages/drawnix/src/data/image.ts
@@ -194,12 +194,14 @@ export async function loadImageElementForCanvas(
     'serviceWorker' in navigator &&
     !!navigator.serviceWorker.controller;
 
-  if (isVirtualMediaUrl(imageUrl) && !canUseServiceWorker) {
+  if (isVirtualMediaUrl(imageUrl)) {
     const cachedBlob = await unifiedCacheService.getCachedBlob(imageUrl);
-    if (!cachedBlob || cachedBlob.size === 0) {
+    if (cachedBlob && cachedBlob.size > 0) {
+      return loadHTMLImageElementFromBlob(cachedBlob);
+    }
+    if (!canUseServiceWorker) {
       throw new Error('图片缓存不可用，请重新生成或上传');
     }
-    return loadHTMLImageElementFromBlob(cachedBlob);
   }
 
   return loadHTMLImageElementWithRetry(imageUrl, true);

--- a/packages/drawnix/src/hooks/__tests__/useAutoInsertToCanvas.test.ts
+++ b/packages/drawnix/src/hooks/__tests__/useAutoInsertToCanvas.test.ts
@@ -49,6 +49,7 @@ const mocks = vi.hoisted(() => {
     boundBoardId: 'board-1' as string | null,
     boundTargetFollowEnabled: true,
     readBoundTargetFollowEnabled: vi.fn(),
+    getInsertionPointBelowBottommostElement: vi.fn(() => [100, 100]),
   };
 });
 
@@ -198,7 +199,8 @@ vi.mock('../../utils/image-splitter', () => ({
 }));
 
 vi.mock('../../utils/selection-utils', () => ({
-  getInsertionPointBelowBottommostElement: vi.fn(() => [100, 100]),
+  getInsertionPointBelowBottommostElement:
+    mocks.getInsertionPointBelowBottommostElement,
   notifyAISelectionContentRefresh: mocks.notifyAISelectionContentRefresh,
 }));
 
@@ -306,6 +308,8 @@ describe('useAutoInsertToCanvas', () => {
     mocks.readBoundTargetFollowEnabled.mockImplementation(
       () => mocks.boundTargetFollowEnabled
     );
+    mocks.getInsertionPointBelowBottommostElement.mockReset();
+    mocks.getInsertionPointBelowBottommostElement.mockReturnValue([100, 100]);
     mocks.quickInsert.mockReset();
     mocks.quickInsert.mockResolvedValue({
       success: true,
@@ -476,6 +480,80 @@ describe('useAutoInsertToCanvas', () => {
       [100, 100],
       'image-1',
       { width: 512, height: 512 }
+    );
+  });
+
+  it('uses returned image dimensions instead of the requested square size', async () => {
+    const task = createCompletedImageTask({
+      params: {
+        prompt: '竖版海报',
+        size: '1:1',
+        autoInsertToCanvas: true,
+      },
+      result: {
+        url: '/__aitu_cache__/image/portrait.png',
+        format: 'png',
+        size: 123,
+        width: 1024,
+        height: 1536,
+      },
+    });
+    mocks.board = { children: [] };
+    mocks.taskState.tasks = [task];
+
+    renderHook(() =>
+      useAutoInsertToCanvas({
+        enabled: true,
+        groupSimilarTasks: true,
+        groupTimeWindow: 10,
+      })
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    expect(mocks.quickInsert).toHaveBeenCalledWith(
+      'image',
+      '/__aitu_cache__/image/portrait.png',
+      [100, 100],
+      { width: 400, height: 600 },
+      expect.any(Object),
+      mocks.board,
+      expect.any(Function)
+    );
+  });
+
+  it('falls back to a valid insertion point on an empty canvas', async () => {
+    const task = createCompletedImageTask();
+    mocks.board = { children: [], viewport: { zoom: 1 } };
+    mocks.taskState.tasks = [task];
+    mocks.getInsertionPointBelowBottommostElement.mockReturnValue(undefined);
+
+    renderHook(() =>
+      useAutoInsertToCanvas({
+        enabled: true,
+        groupSimilarTasks: true,
+        groupTimeWindow: 10,
+      })
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    expect(mocks.quickInsert).toHaveBeenCalledWith(
+      'image',
+      '/__aitu_cache__/image/task-1.png',
+      [0, 0],
+      { width: 512, height: 512 },
+      expect.any(Object),
+      mocks.board,
+      expect.any(Function)
+    );
+    expect(mocks.failPostProcessing).not.toHaveBeenCalledWith(
+      task.id,
+      'No insertion point available'
     );
   });
 

--- a/packages/drawnix/src/hooks/__tests__/useAutoInsertToCanvas.test.ts
+++ b/packages/drawnix/src/hooks/__tests__/useAutoInsertToCanvas.test.ts
@@ -1767,6 +1767,8 @@ describe('useAutoInsertToCanvas', () => {
         url: '/__aitu_cache__/image/batch-1.png',
         format: 'png',
         size: 123,
+        width: 1536,
+        height: 1024,
       },
     });
     const secondTask = createCompletedImageTask({
@@ -1780,6 +1782,8 @@ describe('useAutoInsertToCanvas', () => {
         url: '/__aitu_cache__/image/batch-2.png',
         format: 'png',
         size: 123,
+        width: 1024,
+        height: 1536,
       },
     });
     mocks.board = {
@@ -1801,6 +1805,29 @@ describe('useAutoInsertToCanvas', () => {
       ],
     };
     mocks.taskState.tasks = [firstTask, secondTask];
+    mocks.insertImageGroup.mockResolvedValueOnce({
+      success: true,
+      data: {
+        insertedCount: 2,
+        items: [
+          {
+            type: 'image',
+            point: [100, 100],
+            elementId: 'image-1',
+            size: { width: 512, height: 341 },
+          },
+          {
+            type: 'image',
+            point: [632, 100],
+            elementId: 'image-2',
+            size: { width: 400, height: 600 },
+          },
+        ],
+        firstElementId: 'image-1',
+        firstElementPosition: [100, 100],
+        firstElementSize: { width: 512, height: 341 },
+      },
+    });
 
     renderHook(() =>
       useAutoInsertToCanvas({
@@ -1820,7 +1847,10 @@ describe('useAutoInsertToCanvas', () => {
         '/__aitu_cache__/image/batch-2.png',
       ],
       [100, 100],
-      { width: 512, height: 512 },
+      [
+        { width: 512, height: 341 },
+        { width: 400, height: 600 },
+      ],
       mocks.board,
       expect.any(Function),
       '批量图片'
@@ -1843,14 +1873,14 @@ describe('useAutoInsertToCanvas', () => {
       1,
       [100, 100],
       'image-1',
-      { width: 512, height: 512 }
+      { width: 512, height: 341 }
     );
     expect(mocks.completePostProcessing).toHaveBeenCalledWith(
       'task-batch-2',
       1,
       [632, 100],
       'image-2',
-      { width: 512, height: 512 }
+      { width: 400, height: 600 }
     );
   });
 

--- a/packages/drawnix/src/hooks/useAutoInsertToCanvas.ts
+++ b/packages/drawnix/src/hooks/useAutoInsertToCanvas.ts
@@ -12,7 +12,13 @@
  */
 
 import { useEffect, useRef } from 'react';
-import { Transforms, type PlaitBoard, type Point } from '@plait/core';
+import {
+  getViewportOrigination,
+  PlaitBoard as PlaitBoardApi,
+  Transforms,
+  type PlaitBoard,
+  type Point,
+} from '@plait/core';
 import { PlaitDrawElement } from '@plait/draw';
 import { getTaskQueueService } from '../services/task-queue';
 import { workflowCompletionService } from '../services/workflow-completion-service';
@@ -78,6 +84,7 @@ import {
   getLyricsTitle,
   isLyricsTask,
 } from '../utils/lyrics-task-utils';
+import { resolveImageTaskInsertionDimensions } from '../utils/task-utils';
 import { getImageGenerationTaskInsertGroupKey } from '../utils/image-generation-anchor-task';
 import { findImageGenerationAnchorForTaskOnBoard } from '../utils/image-generation-anchor-lookup';
 import {
@@ -737,32 +744,6 @@ function isDimensions(
   );
 }
 
-function getTaskImageDimensions(
-  task: Task,
-  fallback?: { width: number; height: number }
-): { width: number; height: number } | undefined {
-  // 优先使用任务返回的真实尺寸
-  const result = task.result as { width?: number; height?: number } | undefined;
-
-  if (
-    typeof result?.width === 'number' &&
-    typeof result?.height === 'number' &&
-    result.width > 0 &&
-    result.height > 0
-  ) {
-    return {
-      width: result.width,
-      height: result.height,
-    };
-  }
-
-  if (fallback) {
-    return fallback;
-  }
-
-  return parseSizeToPixels(task.params.size);
-}
-
 function resolveAnchorInsertionPreviewSize(
   anchor: PlaitImageGenerationAnchor | null,
   size?: { width: number; height: number }
@@ -966,12 +947,32 @@ function resolvePendingInsertContext(
     insertionPoint = getInsertionPointBelowBottommostElement(board);
   }
 
+  if (!insertionPoint) {
+    insertionPoint = getViewportCenterInsertionPoint(board);
+  }
+
   return {
     insertionPoint,
     targetFrameId,
     targetFrameDimensions,
     imageAnchor,
   };
+}
+
+function getViewportCenterInsertionPoint(board: PlaitBoard): Point {
+  try {
+    const container = PlaitBoardApi.getBoardContainer(board);
+    const rect = container.getBoundingClientRect();
+    const zoom = Math.max(Number(board.viewport?.zoom) || 1, 0.001);
+    const origination = getViewportOrigination(board) || [0, 0];
+
+    return [
+      origination[0] + rect.width / (2 * zoom),
+      origination[1] + rect.height / (2 * zoom),
+    ];
+  } catch {
+    return [0, 0];
+  }
 }
 
 /**
@@ -1232,7 +1233,7 @@ export function useAutoInsertToCanvas(
               : task.type === TaskType.AUDIO
               ? 'audio'
               : 'image';
-            const dimensions =
+            const requestedDimensions =
               type === 'audio'
                 ? {
                     width: AUDIO_CARD_DEFAULT_WIDTH,
@@ -1241,6 +1242,13 @@ export function useAutoInsertToCanvas(
                 : type === 'text'
                 ? undefined
                 : parseSizeToPixels(task.params.size);
+            const dimensions =
+              type === 'image'
+                ? resolveImageTaskInsertionDimensions(
+                    task,
+                    requestedDimensions?.width
+                  )
+                : requestedDimensions;
             const audioMetadata =
               type === 'audio'
                 ? {
@@ -1343,9 +1351,7 @@ export function useAutoInsertToCanvas(
                   }
                 : generationMetadata;
             const targetImageDimensions =
-              type === 'image'
-                ? getTaskImageDimensions(task, dimensions)
-                : undefined;
+              type === 'image' ? dimensions : undefined;
             let insertedPoint = resolvedInsertionPoint;
             let insertedElementId: string | undefined;
             let insertedSize =
@@ -1850,7 +1856,7 @@ export function useAutoInsertToCanvas(
               : firstInsertTask.type === TaskType.AUDIO
               ? 'audio'
               : 'image';
-            const dimensions =
+            const requestedDimensions =
               type === 'audio'
                 ? {
                     width: AUDIO_CARD_DEFAULT_WIDTH,
@@ -1859,15 +1865,20 @@ export function useAutoInsertToCanvas(
                 : type === 'text'
                 ? undefined
                 : parseSizeToPixels(firstInsertTask.params.size);
+            const dimensions =
+              type === 'image'
+                ? resolveImageTaskInsertionDimensions(
+                    firstInsertTask,
+                    requestedDimensions?.width
+                  )
+                : requestedDimensions;
             const groupImageAnchor =
               type === 'image'
                 ? scopedImageAnchor ??
                   findImageGenerationAnchorForTask(board, firstInsertTask)
                 : null;
             const groupImageDimensions =
-              type === 'image'
-                ? getTaskImageDimensions(firstInsertTask, dimensions)
-                : undefined;
+              type === 'image' ? dimensions : undefined;
             let insertedPoint = resolvedInsertionPoint;
             let insertedElementId: string | undefined;
             let insertedSize = groupImageDimensions;

--- a/packages/drawnix/src/hooks/useAutoInsertToCanvas.ts
+++ b/packages/drawnix/src/hooks/useAutoInsertToCanvas.ts
@@ -1817,6 +1817,10 @@ export function useAutoInsertToCanvas(
                       url: resultUrl,
                       anchor: taskAnchor,
                       metadata: taskMetadata,
+                      dimensions: resolveImageTaskInsertionDimensions(
+                        task,
+                        parseSizeToPixels(task.params.size).width
+                      ),
                     }));
                   })
                 : [];
@@ -1980,7 +1984,10 @@ export function useAutoInsertToCanvas(
                 (resultUrl, index) => ({
                   type,
                   url: resultUrl,
-                  dimensions,
+                  dimensions:
+                    type === 'image'
+                      ? imageGroupItems[index]?.dimensions ?? dimensions
+                      : dimensions,
                   metadata:
                     type === 'image'
                       ? imageGroupItems[index]?.metadata
@@ -2041,7 +2048,7 @@ export function useAutoInsertToCanvas(
                 const insertionResult = await insertImageGroup(
                   urls,
                   resolvedInsertionPoint,
-                  dimensions,
+                  imageGroupItems.map((item) => item.dimensions),
                   board,
                   () => isCanvasInsertionBoardTokenCurrent(insertionBoardToken),
                   firstInsertTask.params.prompt

--- a/packages/drawnix/src/services/canvas-operations/canvas-insertion.test.ts
+++ b/packages/drawnix/src/services/canvas-operations/canvas-insertion.test.ts
@@ -111,7 +111,11 @@ vi.mock('./canvas-board-ref', () => ({
   setCanvasBoard: vi.fn(),
 }));
 
-import { executeCanvasInsertion, insertAIFlow } from './canvas-insertion';
+import {
+  executeCanvasInsertion,
+  insertAIFlow,
+  insertImageGroup,
+} from './canvas-insertion';
 
 function createBoard(): PlaitBoard {
   return { children: [] } as unknown as PlaitBoard;
@@ -267,6 +271,67 @@ describe('canvas insertion service metadata binding', () => {
     expect(board.children.map((item) => (item as any).url)).toEqual([
       'first.png',
       'second.png',
+    ]);
+  });
+
+  it('preserves each generated image dimensions in a mixed-ratio group', async () => {
+    const board = createBoard();
+    mocks.insertImageFromUrl.mockImplementation(
+      async (
+        targetBoard: PlaitBoard,
+        url: string,
+        _point: unknown,
+        _isDrop: unknown,
+        dimensions: { width: number; height: number }
+      ) => {
+        const id = `image-${targetBoard.children.length}`;
+        targetBoard.children.push({ id, type: 'image', url } as any);
+        return id;
+      }
+    );
+
+    const result = await insertImageGroup(
+      ['landscape.png', 'portrait.png'],
+      [100, 100],
+      [
+        { width: 512, height: 341 },
+        { width: 400, height: 600 },
+      ],
+      board
+    );
+
+    expect(result.success).toBe(true);
+    expect(mocks.insertImageFromUrl).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      'landscape.png',
+      expect.anything(),
+      false,
+      { width: 512, height: 341 },
+      true,
+      false,
+      true,
+      true,
+      undefined,
+      true
+    );
+    expect(mocks.insertImageFromUrl).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      'portrait.png',
+      expect.anything(),
+      false,
+      { width: 400, height: 600 },
+      true,
+      false,
+      true,
+      true,
+      undefined,
+      true
+    );
+    expect((result.data as any).items.map((item: any) => item.size)).toEqual([
+      { width: 512, height: 341 },
+      { width: 400, height: 600 },
     ]);
   });
 

--- a/packages/drawnix/src/services/canvas-operations/canvas-insertion.ts
+++ b/packages/drawnix/src/services/canvas-operations/canvas-insertion.ts
@@ -954,7 +954,9 @@ export async function quickInsert(
 export async function insertImageGroup(
   imageUrls: string[],
   point?: Point,
-  dimensions?: { width: number; height: number },
+  dimensions?:
+    | { width: number; height: number }
+    | Array<{ width: number; height: number }>,
   board?: PlaitBoard,
   boardGuard?: () => boolean,
   prompt?: string,
@@ -969,11 +971,11 @@ export async function insertImageGroup(
   };
   return executeCanvasInsertion({
     board,
-    items: imageUrls.map((url) => ({
+    items: imageUrls.map((url, index) => ({
       type: 'image' as ContentType,
       content: url,
       groupId,
-      dimensions,
+      dimensions: Array.isArray(dimensions) ? dimensions[index] : dimensions,
       waitForImageLoad: true,
       metadata:
         Object.keys(promptMetadata).length > 0 ? promptMetadata : undefined,

--- a/packages/drawnix/src/services/canvas-operations/canvas-insertion.ts
+++ b/packages/drawnix/src/services/canvas-operations/canvas-insertion.ts
@@ -354,7 +354,7 @@ async function insertImageToCanvas(
     lockReferenceDimensions: Boolean(dimensions),
     skipImageLoad: !waitForImageLoad,
   });
-  // 自动插入可先用默认尺寸；用户主动插入会等待加载验证
+  // 图片在写入画布前必须验证可读，避免任务成功但画布留下空节点。
   // skipSelect=true: 自动插入时不选中新图片，避免覆盖用户当前选中状态
   // 提供尺寸时锁定布局，避免批量图片异步放大后互相重叠
   const elementId = await insertImageFromUrl(
@@ -934,7 +934,15 @@ export async function quickInsert(
 ): Promise<MCPResult> {
   return executeCanvasInsertion({
     board,
-    items: [{ type, content, dimensions, metadata }],
+    items: [
+      {
+        type,
+        content,
+        dimensions,
+        metadata,
+        waitForImageLoad: type === 'image',
+      },
+    ],
     startPoint: point,
     boardGuard,
   });
@@ -966,6 +974,7 @@ export async function insertImageGroup(
       content: url,
       groupId,
       dimensions,
+      waitForImageLoad: true,
       metadata:
         Object.keys(promptMetadata).length > 0 ? promptMetadata : undefined,
     })),
@@ -994,6 +1003,7 @@ export async function insertGeneratedImageFlow(
       type: 'image',
       content: result.url,
       dimensions: result.dimensions,
+      waitForImageLoad: true,
       metadata: {
         ...result.metadata,
         ...(normalizedPrompt
@@ -1009,6 +1019,7 @@ export async function insertGeneratedImageFlow(
         content: result.url,
         groupId,
         dimensions: result.dimensions,
+        waitForImageLoad: true,
         metadata: {
           ...result.metadata,
           ...(normalizedPrompt
@@ -1063,6 +1074,7 @@ export async function insertAIFlow(
       type: results[0].type,
       content: results[0].url,
       dimensions: results[0].dimensions,
+      waitForImageLoad: results[0].type === 'image',
       metadata: {
         ...results[0].metadata,
         ...(normalizedPrompt
@@ -1078,6 +1090,7 @@ export async function insertAIFlow(
         content: r.url,
         groupId,
         dimensions: r.dimensions,
+        waitForImageLoad: r.type === 'image',
         metadata: {
           ...r.metadata,
           ...(normalizedPrompt


### PR DESCRIPTION
## 概要

修复生成任务显示成功后，图片在画布中被裁切或完全不显示的问题。

本 PR 让画布节点优先使用服务实际返回的图片尺寸，保证图片比例正确；同时修复空画布无法自动插入、图片加载失败仍留下空节点的问题。

## 根因

1. 自动插入流程此前根据请求参数中的比例计算画布节点尺寸，没有优先使用服务实际返回的宽高。当请求比例与服务输出不一致时，实际的 9:16 图片可能被放进 1:1 节点，只显示部分内容。
2. 空画布没有已有元素或锚点时，自动插入流程找不到插入位置。任务列表会显示生成成功，但画布不会插入图片。
3. 图片资源尚未确认加载成功前就创建画布节点。缓存解析或网络加载失败时，可能留下空白或损坏节点。
4. `/__aitu_cache__/image/...` 是应用内部的虚拟缓存地址，不是供应商直接返回的公网图片地址。它需要通过统一图片缓存服务或 Service Worker 解析后才能渲染。

## 修复内容

- 计算生成图片尺寸时优先使用 `result.width` 和 `result.height`。
- 在现有画布最大尺寸约束下，保留服务实际返回的图片比例。
- 空画布没有已有元素或明确锚点时，使用当前视口中心作为插入位置。
- 图片加载成功后才提交画布节点。
- 对 `/__aitu_cache__/image/...` 优先使用统一图片缓存解析。
- 虚拟缓存资源不可用且没有 Service Worker 时，明确报告加载失败，不创建空节点。
- 增加真实尺寸、空画布插入和图片加载失败场景的回归测试。

## 真实 API 和浏览器验证

已通过真实图片生成服务和可见浏览器流程完成验证。测试结束后已清理凭据，API key 未写入 PR 或代码。

| 场景 | 服务返回尺寸 | 画布节点尺寸 | 结果 |
| --- | ---: | ---: | --- |
| 竖图 9:16 | 943 x 1668 | 339 x 600 | 完整显示 |
| 横图 16:9 | 1668 x 943 | 400 x 226 | 完整显示 |

浏览器中已确认：

- 两张生成图片都出现在任务列表。
- 两张生成图片都成功渲染到画布。
- 画布中的 `img` 均已完成加载，`naturalWidth` 和 `naturalHeight` 非零。
- 没有留下损坏或空白的画布图片节点。
- 验证流程的浏览器诊断日志没有发现 warning 或 error。
- 真实返回 URL 类型为 `/__aitu_cache__/image/...png`，并通过应用虚拟缓存路径正常渲染。

修复前曾在浏览器中复现空画布插入失败；加入视口中心回退逻辑后已确认可以正常插入。

## 自动化验证

已通过：

- `pnpm exec nx run drawnix:typecheck`
- 4 个定向 Vitest 测试文件
- 共 69 个定向测试
- `git diff --check`

定向测试命令：

```bash
pnpm exec vitest run --environment jsdom \
  packages/drawnix/src/hooks/__tests__/useAutoInsertToCanvas.test.ts \
  packages/drawnix/src/utils/__tests__/task-utils.test.ts \
  packages/drawnix/src/data/image.test.ts \
  packages/drawnix/src/services/canvas-operations/canvas-insertion.test.ts
```

其中两条 stderr 是负向测试按预期模拟的错误：

- 后续图片加载失败
- 切换画板时取消操作

它们不代表测试失败。

## 行为边界和风险

- 现有画布最大尺寸约束保持不变，本次只调整图片比例来源和插入可靠性。
- 非虚拟缓存的远程图片仍沿用原有加载流程，但必须加载成功后才会插入。
- 图片无法加载或解析时，不再创建空白画布节点；已成功的任务仍保留在任务列表中，可用于诊断或重试。
- 未执行断网注入场景；图片加载失败后不创建节点的事务路径已由自动化测试覆盖。
- 未执行完整 monorepo 全量测试，本次验证范围为 Drawnix 类型检查和上述 69 个定向测试。

## 发布后监控建议

上线后建议关注：

- 任务成功但画布未插入的情况；
- `/__aitu_cache__/image/...` 资源解析失败；
- 服务返回尺寸与画布节点比例不一致；
- 按供应商和 URL 类型统计的图片加载失败。

建议做一次生产冒烟测试，分别生成一张竖图和横图，同时确认任务列表缩略图和画布图片都正常显示。

## 回滚方式

如需回滚，可恢复提交 `347a2631` 之前的版本。此次变更不涉及数据迁移、配置变更或持久化结构调整。
