### PR TITLE
修复 Suno 纯音乐、多音轨结果与画布播放

### DIFF
--- a/packages/drawnix/src/components/audio-node-element/audio-node-content.scss
+++ b/packages/drawnix/src/components/audio-node-element/audio-node-content.scss
@@ -118,8 +118,7 @@
   );
   border: 1px solid rgba(255, 255, 255, 0.48);
   box-shadow: 0 16px 30px rgba(15, 23, 42, 0.16),
-    0 0 0 1px rgba(15, 23, 42, 0.04),
-    inset 0 1px 0 rgba(255, 255, 255, 0.22);
+    0 0 0 1px rgba(15, 23, 42, 0.04), inset 0 1px 0 rgba(255, 255, 255, 0.22);
   cursor: pointer;
   isolation: isolate;
   transform: scale(var(--audio-node-pulse-scale));
@@ -164,8 +163,7 @@
   &:hover,
   &:focus-visible {
     box-shadow: 0 18px 34px rgba(15, 23, 42, 0.2),
-      0 0 0 1px rgba(37, 99, 235, 0.16),
-      inset 0 1px 0 rgba(255, 255, 255, 0.28);
+      0 0 0 1px rgba(37, 99, 235, 0.16), inset 0 1px 0 rgba(255, 255, 255, 0.28);
   }
 
   &:hover::before,
@@ -193,7 +191,7 @@
   justify-content: center;
   color: #ffffff;
   background: rgba(15, 23, 42, 0.28);
-  opacity: 0;
+  opacity: 1;
   transition: background-color 0.18s ease, opacity 0.18s ease,
     transform 0.18s ease;
 
@@ -211,6 +209,7 @@
 .audio-node__artwork:hover .audio-node__artwork-overlay,
 .audio-node__artwork:focus-visible .audio-node__artwork-overlay {
   opacity: 1;
+  background: rgba(15, 23, 42, 0.38);
 }
 
 .audio-node__artwork:hover .audio-node__artwork-icon,

--- a/packages/drawnix/src/components/music-analyzer/pages/GeneratePage.tsx
+++ b/packages/drawnix/src/components/music-analyzer/pages/GeneratePage.tsx
@@ -1,4 +1,11 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { Switch } from 'tdesign-react';
 import type {
   GeneratedClip,
   MusicAnalysisRecord,
@@ -12,16 +19,20 @@ import { KnowledgeNoteContextSelector } from '../../shared';
 import { useSelectableModels } from '../../../hooks/use-runtime-models';
 import { getSelectionKey } from '../../../utils/model-selection';
 import type { ModelRef } from '../../../utils/settings-manager';
-import { getCompatibleParams, getDefaultAudioModel } from '../../../constants/model-config';
 import {
-  readStoredModelSelection,
-  writeStoredModelSelection,
-} from '../utils';
+  getCompatibleParams,
+  getDefaultAudioModel,
+} from '../../../constants/model-config';
+import { readStoredModelSelection, writeStoredModelSelection } from '../utils';
 import { analytics } from '../../../utils/umami-analytics';
 
 const STORAGE_KEY_AUDIO_MODEL = 'music-analyzer:audio-model';
 
-const ACTION_OPTIONS: Array<{ id: SunoMusicEditAction; label: string; hint: string }> = [
+const ACTION_OPTIONS: Array<{
+  id: SunoMusicEditAction;
+  label: string;
+  hint: string;
+}> = [
   { id: 'generate', label: '新生成', hint: '从零生成完整音乐' },
   { id: 'continue', label: '续写', hint: '从已有片段继续创作' },
   { id: 'infill', label: 'Infill', hint: '局部重绘指定时间窗口' },
@@ -45,7 +56,9 @@ function toOptionalNumber(value: string): number | null {
 }
 
 function toNumberInputValue(value?: number | null): string {
-  return typeof value === 'number' && Number.isFinite(value) ? String(value) : '';
+  return typeof value === 'number' && Number.isFinite(value)
+    ? String(value)
+    : '';
 }
 
 function toStyleTags(value: string): string[] {
@@ -56,7 +69,9 @@ function toStyleTags(value: string): string[] {
 }
 
 function getActionLabel(action: SunoMusicEditAction): string {
-  return ACTION_OPTIONS.find((option) => option.id === action)?.label || '新生成';
+  return (
+    ACTION_OPTIONS.find((option) => option.id === action)?.label || '新生成'
+  );
 }
 
 function getDefaultContinueAt(clip: GeneratedClip): string {
@@ -82,21 +97,30 @@ export const GeneratePage: React.FC<GeneratePageProps> = ({
   const [title, setTitle] = useState(record.title || '');
   const [tags, setTags] = useState((record.styleTags || []).join(', '));
   const [prompt, setPrompt] = useState(record.lyricsDraft || '');
+  const [instrumental, setInstrumental] = useState(
+    record.instrumental === true
+  );
   const [knowledgeContextRefs, setKnowledgeContextRefs] = useState<
     KnowledgeContextRef[]
   >([]);
   const [mv, setMv] = useState('chirp-v5-5');
   const [batchCount, setBatchCount] = useState(1);
   const [selectedModel, setSelectedModelState] = useState(
-    () => readStoredModelSelection(STORAGE_KEY_AUDIO_MODEL, getDefaultAudioModel()).modelId
+    () =>
+      readStoredModelSelection(STORAGE_KEY_AUDIO_MODEL, getDefaultAudioModel())
+        .modelId
   );
   const [selectedModelRef, setSelectedModelRef] = useState<ModelRef | null>(
-    () => readStoredModelSelection(STORAGE_KEY_AUDIO_MODEL, getDefaultAudioModel()).modelRef
+    () =>
+      readStoredModelSelection(STORAGE_KEY_AUDIO_MODEL, getDefaultAudioModel())
+        .modelRef
   );
   const [action, setAction] = useState<SunoMusicEditAction>(
     record.musicEditAction || 'generate'
   );
-  const [continueClipId, setContinueClipId] = useState(record.continueFromClipId || '');
+  const [continueClipId, setContinueClipId] = useState(
+    record.continueFromClipId || ''
+  );
   const [continueAtInput, setContinueAtInput] = useState(
     toNumberInputValue(record.continueAt)
   );
@@ -111,16 +135,20 @@ export const GeneratePage: React.FC<GeneratePageProps> = ({
   const saveTimerRef = useRef<ReturnType<typeof setTimeout>>();
   const generatingRef = useRef(false);
 
-  const setSelectedModel = useCallback((model: string, modelRef?: ModelRef | null) => {
-    setSelectedModelState(model);
-    setSelectedModelRef(modelRef || null);
-    writeStoredModelSelection(STORAGE_KEY_AUDIO_MODEL, model, modelRef);
-  }, []);
+  const setSelectedModel = useCallback(
+    (model: string, modelRef?: ModelRef | null) => {
+      setSelectedModelState(model);
+      setSelectedModelRef(modelRef || null);
+      writeStoredModelSelection(STORAGE_KEY_AUDIO_MODEL, model, modelRef);
+    },
+    []
+  );
 
   useEffect(() => {
     setTitle(record.title || '');
     setTags((record.styleTags || []).join(', '));
     setPrompt(record.lyricsDraft || '');
+    setInstrumental(record.instrumental === true);
     setAction(record.musicEditAction || 'generate');
     setContinueClipId(record.continueFromClipId || '');
     setContinueAtInput(toNumberInputValue(record.continueAt));
@@ -139,6 +167,7 @@ export const GeneratePage: React.FC<GeneratePageProps> = ({
         title,
         styleTags,
         lyricsDraft: prompt,
+        instrumental,
         musicEditAction: action,
         continueFromClipId: continueClipId || null,
         continueAt,
@@ -163,6 +192,7 @@ export const GeneratePage: React.FC<GeneratePageProps> = ({
     onRecordsChange,
     prompt,
     record.id,
+    instrumental,
     tags,
     title,
   ]);
@@ -195,7 +225,8 @@ export const GeneratePage: React.FC<GeneratePageProps> = ({
     [clips]
   );
   const selectedClip = useMemo(
-    () => selectableClips.find((clip) => clip.clipId === continueClipId) || null,
+    () =>
+      selectableClips.find((clip) => clip.clipId === continueClipId) || null,
     [continueClipId, selectableClips]
   );
   const requiresContinuation = action !== 'generate';
@@ -212,9 +243,13 @@ export const GeneratePage: React.FC<GeneratePageProps> = ({
       setContinueClipId(clip.clipId);
       setContinueAtInput((current) => current || getDefaultContinueAt(clip));
       if (nextAction === 'continue') {
-        setMessage(`已带入片段「${clip.title || clip.clipId.slice(0, 8)}」用于续写`);
+        setMessage(
+          `已带入片段「${clip.title || clip.clipId.slice(0, 8)}」用于续写`
+        );
       } else {
-        setMessage(`已带入片段「${clip.title || clip.clipId.slice(0, 8)}」用于 Infill`);
+        setMessage(
+          `已带入片段「${clip.title || clip.clipId.slice(0, 8)}」用于 Infill`
+        );
       }
     },
     []
@@ -289,6 +324,7 @@ export const GeneratePage: React.FC<GeneratePageProps> = ({
         promptLength: trimmedPrompt.length,
         hasTitle: !!trimmedTitle,
         tagsCount: toStyleTags(trimmedTags).length,
+        instrumental,
         hasMv: !!mv,
         hasModelRef: !!selectedModelRef,
       },
@@ -308,11 +344,18 @@ export const GeneratePage: React.FC<GeneratePageProps> = ({
             sunoAction: 'music',
             title: trimmedTitle,
             tags: trimmedTags,
+            instrumental,
             mv,
             continueClipId: requiresContinuation ? continueClipId : undefined,
-            continueTaskId: requiresContinuation ? selectedClip?.taskId : undefined,
-            continueAt: requiresContinuation ? continueAt ?? undefined : undefined,
-            infillStartS: requiresInfill ? infillStartS ?? undefined : undefined,
+            continueTaskId: requiresContinuation
+              ? selectedClip?.taskId
+              : undefined,
+            continueAt: requiresContinuation
+              ? continueAt ?? undefined
+              : undefined,
+            infillStartS: requiresInfill
+              ? infillStartS ?? undefined
+              : undefined,
             infillEndS: requiresInfill ? infillEndS ?? undefined : undefined,
             knowledgeContextRefs,
             batchId: `ma_${record.id}_${batchAction}_${i}`,
@@ -330,6 +373,7 @@ export const GeneratePage: React.FC<GeneratePageProps> = ({
         title: trimmedTitle,
         styleTags: toStyleTags(trimmedTags),
         lyricsDraft: trimmedPrompt,
+        instrumental,
         musicEditAction: action,
         continueFromClipId: continueClipId || null,
         continueAt,
@@ -342,7 +386,9 @@ export const GeneratePage: React.FC<GeneratePageProps> = ({
         ...record,
         ...patch,
       });
-      setMessage(`已提交 ${batchCount} 次${getActionLabel(action)}任务到 Suno 队列`);
+      setMessage(
+        `已提交 ${batchCount} 次${getActionLabel(action)}任务到 Suno 队列`
+      );
     } catch (taskError: any) {
       setMessage(taskError.message || '提交生成任务失败');
     } finally {
@@ -356,6 +402,7 @@ export const GeneratePage: React.FC<GeneratePageProps> = ({
     continueClipId,
     infillEndInput,
     infillStartInput,
+    instrumental,
     knowledgeContextRefs,
     mv,
     onRecordUpdate,
@@ -384,7 +431,9 @@ export const GeneratePage: React.FC<GeneratePageProps> = ({
           {ACTION_OPTIONS.map((option) => (
             <button
               key={option.id}
-              className={`ma-action-btn ${action === option.id ? 'active' : ''}`}
+              className={`ma-action-btn ${
+                action === option.id ? 'active' : ''
+              }`}
               onClick={() => setAction(option.id)}
             >
               {option.label}
@@ -399,7 +448,10 @@ export const GeneratePage: React.FC<GeneratePageProps> = ({
         </div>
         <ModelDropdown
           selectedModel={selectedModel}
-          selectedSelectionKey={getSelectionKey(selectedModel, selectedModelRef)}
+          selectedSelectionKey={getSelectionKey(
+            selectedModel,
+            selectedModelRef
+          )}
           onSelect={setSelectedModel}
           models={sunoModels.length > 0 ? sunoModels : audioModels}
           variant="form"
@@ -447,7 +499,9 @@ export const GeneratePage: React.FC<GeneratePageProps> = ({
               ))}
             </select>
           ) : (
-            <div className="ma-hint">先生成至少一个片段，才能使用续写或 Infill。</div>
+            <div className="ma-hint">
+              先生成至少一个片段，才能使用续写或 Infill。
+            </div>
           )}
           {selectedClip && (
             <div className="ma-hint">
@@ -462,7 +516,11 @@ export const GeneratePage: React.FC<GeneratePageProps> = ({
           <div className="ma-card-header">
             <span>编辑参数</span>
           </div>
-          <div className={`ma-fields-grid ${requiresInfill ? 'ma-fields-grid--triple' : ''}`}>
+          <div
+            className={`ma-fields-grid ${
+              requiresInfill ? 'ma-fields-grid--triple' : ''
+            }`}
+          >
             <label className="ma-field">
               <span>续写起点秒数</span>
               <input
@@ -531,16 +589,36 @@ export const GeneratePage: React.FC<GeneratePageProps> = ({
         />
       </div>
 
+      <div className="ma-card ma-instrumental-card">
+        <div className="ma-card-header">
+          <span>纯音乐模式</span>
+          <span className="ma-muted">强制传递给 Suno，避免生成演唱或朗诵</span>
+        </div>
+        <Switch
+          value={instrumental}
+          onChange={(value) => setInstrumental(Boolean(value))}
+          label={instrumental ? '仅生成纯音乐' : '生成歌曲（可包含人声）'}
+        />
+      </div>
+
       <div className="ma-card">
         <div className="ma-card-header">
-          <span>提交给 Suno 的歌词/提示词</span>
+          <span>
+            {instrumental
+              ? '提交给 Suno 的纯音乐描述/提示词'
+              : '提交给 Suno 的歌词/提示词'}
+          </span>
         </div>
         <textarea
           className="ma-textarea"
           rows={10}
           value={prompt}
           onChange={(event) => setPrompt(event.target.value)}
-          placeholder="这里的内容会直接作为 prompt 提交给 Suno"
+          placeholder={
+            instrumental
+              ? '描述乐器、节奏、情绪和场景，例如：舒缓钢琴与弦乐纯音乐，无人声'
+              : '这里的内容会直接作为 prompt 提交给 Suno'
+          }
         />
         <KnowledgeNoteContextSelector
           value={knowledgeContextRefs}
@@ -632,10 +710,17 @@ const ClipCard: React.FC<{
       <div className="ma-clip-meta">
         <span className="ma-clip-title">{clip.title || '未命名'}</span>
         {clip.duration != null && (
-          <span className="ma-clip-duration">{formatDuration(clip.duration)}</span>
+          <span className="ma-clip-duration">
+            {formatDuration(clip.duration)}
+          </span>
         )}
       </div>
-      <audio controls src={clip.audioUrl} className="ma-clip-player" preload="metadata" />
+      <audio
+        controls
+        src={clip.audioUrl}
+        className="ma-clip-player"
+        preload="metadata"
+      />
       <div className="ma-clip-actions">
         <button
           className="ma-clip-action-btn"

--- a/packages/drawnix/src/components/music-analyzer/pages/LyricsPage.tsx
+++ b/packages/drawnix/src/components/music-analyzer/pages/LyricsPage.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
 } from 'react';
 import type { MusicAnalysisRecord } from '../types';
+import { Switch } from 'tdesign-react';
 import { formatLyricsMarkdown } from '../types';
 import { updateRecord } from '../storage';
 import { taskQueueService } from '../../../services/task-queue';
@@ -65,6 +66,9 @@ export const LyricsPage: React.FC<LyricsPageProps> = ({
   const [styleTagsInput, setStyleTagsInput] = useState(
     (record.styleTags || record.analysis?.genreTags || []).join(', ')
   );
+  const [instrumental, setInstrumental] = useState(
+    record.instrumental === true
+  );
   const [musicBrief, setMusicBrief] = useState<MusicBrief>(() =>
     normalizeMusicBrief(record.musicBrief)
   );
@@ -105,6 +109,7 @@ export const LyricsPage: React.FC<LyricsPageProps> = ({
     setStyleTagsInput(
       (record.styleTags || record.analysis?.genreTags || []).join(', ')
     );
+    setInstrumental(record.instrumental === true);
     setMusicBrief((current) => {
       const next = normalizeMusicBrief(record.musicBrief);
       return areMusicBriefsEqual(current, next) ? current : next;
@@ -124,6 +129,7 @@ export const LyricsPage: React.FC<LyricsPageProps> = ({
         lyricsDraft,
         title,
         styleTags,
+        instrumental,
         musicBrief: normalizeMusicBrief(musicBrief),
         pendingRewriteTaskId,
       });
@@ -134,6 +140,7 @@ export const LyricsPage: React.FC<LyricsPageProps> = ({
         lyricsDraft,
         title,
         styleTags,
+        instrumental,
         musicBrief: normalizeMusicBrief(musicBrief),
         pendingRewriteTaskId,
       });
@@ -148,6 +155,7 @@ export const LyricsPage: React.FC<LyricsPageProps> = ({
     record.id,
     rewritePrompt,
     styleTagsInput,
+    instrumental,
     title,
   ]);
 
@@ -176,6 +184,17 @@ export const LyricsPage: React.FC<LyricsPageProps> = ({
   const activeVersionId = record.activeVersionId || ORIGINAL_VERSION_ID;
   const hasVersions = versions.length > 1;
   const creationPrompt = String(record.creationPrompt || '').trim();
+
+  const handleInstrumentalChange = useCallback(
+    (value: boolean) => {
+      setInstrumental(value);
+      onRecordUpdate({ ...record, instrumental: value });
+      void updateRecord(record.id, { instrumental: value }).then(
+        onRecordsChange
+      );
+    },
+    [onRecordUpdate, onRecordsChange, record]
+  );
 
   const handleSwitchVersion = useCallback(
     async (versionId: string) => {
@@ -386,6 +405,20 @@ export const LyricsPage: React.FC<LyricsPageProps> = ({
         <MusicBriefEditor value={musicBrief} onChange={setMusicBrief} />
       </div>
 
+      <div className="ma-card ma-instrumental-card">
+        <div className="ma-card-header">
+          <span>纯音乐模式</span>
+          <span className="ma-muted">
+            不生成演唱人声，下一步可直接填写音乐描述
+          </span>
+        </div>
+        <Switch
+          value={instrumental}
+          onChange={(value) => handleInstrumentalChange(Boolean(value))}
+          label={instrumental ? '仅生成纯音乐' : '生成歌曲（可包含人声）'}
+        />
+      </div>
+
       <div className="ma-card">
         <div className="ma-card-header">
           <span>改写要求</span>
@@ -455,7 +488,8 @@ export const LyricsPage: React.FC<LyricsPageProps> = ({
             disabled={!!pendingRewriteTaskId}
           >
             {pendingRewriteTaskId
-              ? rewriteProgress || (isSunoModel ? '歌词生成中...' : '歌词改写中...')
+              ? rewriteProgress ||
+                (isSunoModel ? '歌词生成中...' : '歌词改写中...')
               : isSunoModel
               ? 'Suno 生成歌词'
               : 'AI 改写'}
@@ -512,7 +546,7 @@ export const LyricsPage: React.FC<LyricsPageProps> = ({
         <button
           className="va-btn-primary"
           onClick={onNext}
-          disabled={!lyricsDraft.trim()}
+          disabled={!lyricsDraft.trim() && !instrumental}
         >
           下一步
         </button>

--- a/packages/drawnix/src/components/music-analyzer/types.ts
+++ b/packages/drawnix/src/components/music-analyzer/types.ts
@@ -60,6 +60,8 @@ export interface MusicAnalysisRecord {
   lyricsDraft?: string;
   styleTags?: string[];
   title?: string;
+  /** Whether the next Suno generation should be instrumental-only */
+  instrumental?: boolean;
   // 任务追踪
   analyzeTaskId?: string | null;
   pendingRewriteTaskId?: string | null;

--- a/packages/drawnix/src/components/shared/media-preview/MediaViewport.tsx
+++ b/packages/drawnix/src/components/shared/media-preview/MediaViewport.tsx
@@ -3,7 +3,15 @@
  * 复用于单图模式和对比模式的每个槽位
  */
 
-import React, { useRef, useState, useCallback, useEffect, useLayoutEffect, forwardRef, useImperativeHandle } from 'react';
+import React, {
+  useRef,
+  useState,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  forwardRef,
+  useImperativeHandle,
+} from 'react';
 import {
   ZoomIn,
   ZoomOut,
@@ -14,6 +22,7 @@ import {
   GripHorizontal,
   Plus,
   Download,
+  ExternalLink,
   Pencil,
 } from 'lucide-react';
 import { MessagePlugin } from 'tdesign-react';
@@ -124,971 +133,1080 @@ const saveToolbarState = (state: ToolbarCacheState): void => {
   }
 };
 
-export const MediaViewport = forwardRef<MediaViewportRef, MediaViewportProps>(({
-  item,
-  slotIndex,
-  isFocused = false,
-  zoomLevel = 1,
-  panOffset,
-  onClick,
-  videoAutoPlay = false,
-  videoLoop = true,
-  onZoomChange,
-  onPanChange,
-  isCompareMode = false,
-  onInsertToCanvas,
-  onDownload,
-  onEdit,
-  onVideoPlayStateChange,
-  onVideoTimeUpdate,
-  isSyncMode = false,
-}, ref) => {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const videoRef = useRef<HTMLVideoElement>(null);
-  const imageRef = useRef<HTMLImageElement>(null);
-  const [imageLoadFailed, setImageLoadFailed] = useState(false);
-  const [isAutoFitReady, setIsAutoFitReady] = useState(true);
-  const [isDragging, setIsDragging] = useState(false);
-  const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
-  const [localPan, setLocalPan] = useState(panOffset ?? DEFAULT_PAN);
-  const [localZoom, setLocalZoom] = useState(zoomLevel);
-  const localZoomRef = useRef(zoomLevel);
-  const [rotation, setRotation] = useState(0); // 旋转角度
-  const [flipH, setFlipH] = useState(false); // 水平翻转
-  const [flipV, setFlipV] = useState(false); // 垂直翻转
-  const [isMediaHovered, setIsMediaHovered] = useState(false);
-  const [isPromptHovered, setIsPromptHovered] = useState(false);
-  const [isToolbarHovered, setIsToolbarHovered] = useState(false);
-  const promptHideTimerRef = useRef<number | null>(null);
-  const hasManualViewChangeRef = useRef(false);
-  const latestZoomLevelRef = useRef(zoomLevel);
-  const latestPanOffsetRef = useRef(panOffset);
+export const MediaViewport = forwardRef<MediaViewportRef, MediaViewportProps>(
+  (
+    {
+      item,
+      slotIndex,
+      isFocused = false,
+      zoomLevel = 1,
+      panOffset,
+      onClick,
+      videoAutoPlay = false,
+      videoLoop = true,
+      onZoomChange,
+      onPanChange,
+      isCompareMode = false,
+      onInsertToCanvas,
+      onDownload,
+      onEdit,
+      onVideoPlayStateChange,
+      onVideoTimeUpdate,
+      isSyncMode = false,
+    },
+    ref
+  ) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const videoRef = useRef<HTMLVideoElement>(null);
+    const imageRef = useRef<HTMLImageElement>(null);
+    const [imageLoadFailed, setImageLoadFailed] = useState(false);
+    const [isAutoFitReady, setIsAutoFitReady] = useState(true);
+    const [isDragging, setIsDragging] = useState(false);
+    const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
+    const [localPan, setLocalPan] = useState(panOffset ?? DEFAULT_PAN);
+    const [localZoom, setLocalZoom] = useState(zoomLevel);
+    const localZoomRef = useRef(zoomLevel);
+    const [rotation, setRotation] = useState(0); // 旋转角度
+    const [flipH, setFlipH] = useState(false); // 水平翻转
+    const [flipV, setFlipV] = useState(false); // 垂直翻转
+    const [isMediaHovered, setIsMediaHovered] = useState(false);
+    const [isPromptHovered, setIsPromptHovered] = useState(false);
+    const [isToolbarHovered, setIsToolbarHovered] = useState(false);
+    const promptHideTimerRef = useRef<number | null>(null);
+    const hasManualViewChangeRef = useRef(false);
+    const latestZoomLevelRef = useRef(zoomLevel);
+    const latestPanOffsetRef = useRef(panOffset);
 
-  // 暴露视频控制方法给父组件
-  useImperativeHandle(ref, () => ({
-    resetVideo: () => {
-      if (videoRef.current) {
-        videoRef.current.currentTime = 0;
-        videoRef.current.play().catch(() => {
-          // 忽略自动播放限制错误
-        });
-      }
-    },
-    playVideo: () => {
-      if (videoRef.current) {
-        videoRef.current.play().catch(() => {
-          // 忽略自动播放限制错误
-        });
-      }
-    },
-    pauseVideo: () => {
-      if (videoRef.current) {
-        videoRef.current.pause();
-      }
-    },
-    toggleVideoPlayback: () => {
-      if (!videoRef.current) {
-        return;
-      }
-      if (videoRef.current.paused || videoRef.current.ended) {
-        videoRef.current.play().catch(() => {
-          // 忽略自动播放限制错误
-        });
-        return;
-      }
-      videoRef.current.pause();
-    },
-    setVideoTime: (time: number) => {
-      if (videoRef.current) {
-        videoRef.current.currentTime = time;
-      }
-    },
-    getVideoTime: () => {
-      return videoRef.current?.currentTime ?? 0;
-    },
-    isVideo: () => {
-      return item?.type === 'video';
-    },
-  }), [item]);
+    // 暴露视频控制方法给父组件
+    useImperativeHandle(
+      ref,
+      () => ({
+        resetVideo: () => {
+          if (videoRef.current) {
+            videoRef.current.currentTime = 0;
+            videoRef.current.play().catch(() => {
+              // 忽略自动播放限制错误
+            });
+          }
+        },
+        playVideo: () => {
+          if (videoRef.current) {
+            videoRef.current.play().catch(() => {
+              // 忽略自动播放限制错误
+            });
+          }
+        },
+        pauseVideo: () => {
+          if (videoRef.current) {
+            videoRef.current.pause();
+          }
+        },
+        toggleVideoPlayback: () => {
+          if (!videoRef.current) {
+            return;
+          }
+          if (videoRef.current.paused || videoRef.current.ended) {
+            videoRef.current.play().catch(() => {
+              // 忽略自动播放限制错误
+            });
+            return;
+          }
+          videoRef.current.pause();
+        },
+        setVideoTime: (time: number) => {
+          if (videoRef.current) {
+            videoRef.current.currentTime = time;
+          }
+        },
+        getVideoTime: () => {
+          return videoRef.current?.currentTime ?? 0;
+        },
+        isVideo: () => {
+          return item?.type === 'video';
+        },
+      }),
+      [item]
+    );
 
-  // 工具栏状态 - 单图模式从缓存初始化，多图模式使用默认值
-  const [toolbarState] = useState<ToolbarCacheState>(() =>
-    isCompareMode ? { orientation: 'horizontal', position: null } : loadToolbarState()
-  );
-  const [toolbarOrientation, setToolbarOrientation] =
-    useState<ToolbarOrientation>(toolbarState.orientation);
-  const [toolbarPosition, setToolbarPosition] = useState<{
-    x: number;
-    y: number;
-  } | null>(toolbarState.position);
-  const [isToolbarDragging, setIsToolbarDragging] = useState(false);
-  const toolbarDragStartRef = useRef({ x: 0, y: 0, posX: 0, posY: 0 });
-  const isVideo = item?.type === 'video';
-  const isAudio = item?.type === 'audio';
-  const promptText = item?.prompt?.trim() || '';
-  const showPrompt =
-    Boolean(promptText) && (isMediaHovered || isPromptHovered) && !isToolbarHovered;
-  const mediaIdentity = item ? `${item.type}:${item.id || item.url}` : 'empty';
-  const originalMediaUrl =
-    item && (isVideo || isAudio) ? item.url : undefined;
-  const { url: resolvedCachedMediaUrl, isLoading: isMediaUrlLoading } =
-    useMediaUrl(mediaIdentity, originalMediaUrl);
-  const mediaUrl = item
-    ? (isVideo || isAudio
+    // 工具栏状态 - 单图模式从缓存初始化，多图模式使用默认值
+    const [toolbarState] = useState<ToolbarCacheState>(() =>
+      isCompareMode
+        ? { orientation: 'horizontal', position: null }
+        : loadToolbarState()
+    );
+    const [toolbarOrientation, setToolbarOrientation] =
+      useState<ToolbarOrientation>(toolbarState.orientation);
+    const [toolbarPosition, setToolbarPosition] = useState<{
+      x: number;
+      y: number;
+    } | null>(toolbarState.position);
+    const [isToolbarDragging, setIsToolbarDragging] = useState(false);
+    const toolbarDragStartRef = useRef({ x: 0, y: 0, posX: 0, posY: 0 });
+    const isVideo = item?.type === 'video';
+    const isAudio = item?.type === 'audio';
+    const promptText = item?.prompt?.trim() || '';
+    const showPrompt =
+      Boolean(promptText) &&
+      (isMediaHovered || isPromptHovered) &&
+      !isToolbarHovered;
+    const mediaIdentity = item
+      ? `${item.type}:${item.id || item.url}`
+      : 'empty';
+    const originalMediaUrl =
+      item && (isVideo || isAudio) ? item.url : undefined;
+    const { url: resolvedCachedMediaUrl, isLoading: isMediaUrlLoading } =
+      useMediaUrl(mediaIdentity, originalMediaUrl);
+    const mediaUrl = item
+      ? isVideo || isAudio
         ? resolvedCachedMediaUrl || ''
-        : normalizeImageDataUrl(item.url))
-    : '';
-  const posterUrl = item?.posterUrl ? normalizeImageDataUrl(item.posterUrl) : '';
-  const dimensionsLabel = formatMediaItemDimensions(item);
-  const needsAutoFitGate = Boolean(item?.url && !isAudio && !isCompareMode && !imageLoadFailed);
+        : normalizeImageDataUrl(item.url)
+      : '';
+    const posterUrl = item?.posterUrl
+      ? normalizeImageDataUrl(item.posterUrl)
+      : '';
+    const dimensionsLabel = formatMediaItemDimensions(item);
+    const needsAutoFitGate = Boolean(
+      item?.url && !isAudio && !isCompareMode && !imageLoadFailed
+    );
 
-  const clearPromptHideTimer = useCallback(() => {
-    if (promptHideTimerRef.current !== null) {
-      window.clearTimeout(promptHideTimerRef.current);
-      promptHideTimerRef.current = null;
-    }
-  }, []);
-
-  const handleMediaHoverStart = useCallback(() => {
-    clearPromptHideTimer();
-    setIsMediaHovered(true);
-  }, [clearPromptHideTimer]);
-
-  const handleMediaHoverEnd = useCallback(() => {
-    setIsMediaHovered(false);
-    clearPromptHideTimer();
-    promptHideTimerRef.current = window.setTimeout(() => {
-      setIsPromptHovered(false);
-      promptHideTimerRef.current = null;
-    }, 120);
-  }, [clearPromptHideTimer]);
-
-  const handlePromptHoverStart = useCallback(() => {
-    clearPromptHideTimer();
-    setIsPromptHovered(true);
-  }, [clearPromptHideTimer]);
-
-  const handlePromptHoverEnd = useCallback(() => {
-    setIsPromptHovered(false);
-  }, []);
-
-  useLayoutEffect(() => {
-    setImageLoadFailed(false);
-    setIsAutoFitReady(!item?.url || isAudio || isCompareMode);
-    setIsDragging(false);
-    const nextPan = latestPanOffsetRef.current ?? DEFAULT_PAN;
-    const nextZoom = latestZoomLevelRef.current;
-    setLocalPan(nextPan);
-    localZoomRef.current = nextZoom;
-    setLocalZoom(nextZoom);
-    setRotation(0);
-    setFlipH(false);
-    setFlipV(false);
-    hasManualViewChangeRef.current = false;
-  }, [mediaIdentity, item?.url, isAudio, isCompareMode]);
-
-  useEffect(() => () => {
-    clearPromptHideTimer();
-  }, [clearPromptHideTimer]);
-
-  // 保存工具栏状态到缓存 - 仅单图模式
-  useEffect(() => {
-    if (!isCompareMode) {
-      saveToolbarState({ orientation: toolbarOrientation, position: toolbarPosition });
-    }
-  }, [toolbarOrientation, toolbarPosition, isCompareMode]);
-
-  // 同步外部 props - 只在值真正变化时更新
-  useLayoutEffect(() => {
-    const newPan = panOffset ?? DEFAULT_PAN;
-    latestPanOffsetRef.current = panOffset;
-    setLocalPan((prev) => {
-      if (prev.x === newPan.x && prev.y === newPan.y) return prev;
-      return newPan;
-    });
-  }, [panOffset]);
-
-  useLayoutEffect(() => {
-    latestZoomLevelRef.current = zoomLevel;
-    localZoomRef.current = zoomLevel;
-    setLocalZoom((prev) => (prev === zoomLevel ? prev : zoomLevel));
-  }, [zoomLevel]);
-
-  const applyZoom = useCallback(
-    (nextZoom: number, source: 'auto' | 'manual' = 'manual') => {
-      const clampedZoom = clampZoomLevel(nextZoom);
-      if (source === 'manual') {
-        hasManualViewChangeRef.current = true;
+    const clearPromptHideTimer = useCallback(() => {
+      if (promptHideTimerRef.current !== null) {
+        window.clearTimeout(promptHideTimerRef.current);
+        promptHideTimerRef.current = null;
       }
-      if (Math.abs(localZoomRef.current - clampedZoom) <= ZOOM_EPSILON) {
+    }, []);
+
+    const handleMediaHoverStart = useCallback(() => {
+      clearPromptHideTimer();
+      setIsMediaHovered(true);
+    }, [clearPromptHideTimer]);
+
+    const handleMediaHoverEnd = useCallback(() => {
+      setIsMediaHovered(false);
+      clearPromptHideTimer();
+      promptHideTimerRef.current = window.setTimeout(() => {
+        setIsPromptHovered(false);
+        promptHideTimerRef.current = null;
+      }, 120);
+    }, [clearPromptHideTimer]);
+
+    const handlePromptHoverStart = useCallback(() => {
+      clearPromptHideTimer();
+      setIsPromptHovered(true);
+    }, [clearPromptHideTimer]);
+
+    const handlePromptHoverEnd = useCallback(() => {
+      setIsPromptHovered(false);
+    }, []);
+
+    useLayoutEffect(() => {
+      setImageLoadFailed(false);
+      setIsAutoFitReady(!item?.url || isAudio || isCompareMode);
+      setIsDragging(false);
+      const nextPan = latestPanOffsetRef.current ?? DEFAULT_PAN;
+      const nextZoom = latestZoomLevelRef.current;
+      setLocalPan(nextPan);
+      localZoomRef.current = nextZoom;
+      setLocalZoom(nextZoom);
+      setRotation(0);
+      setFlipH(false);
+      setFlipV(false);
+      hasManualViewChangeRef.current = false;
+    }, [mediaIdentity, item?.url, isAudio, isCompareMode]);
+
+    useEffect(
+      () => () => {
+        clearPromptHideTimer();
+      },
+      [clearPromptHideTimer]
+    );
+
+    // 保存工具栏状态到缓存 - 仅单图模式
+    useEffect(() => {
+      if (!isCompareMode) {
+        saveToolbarState({
+          orientation: toolbarOrientation,
+          position: toolbarPosition,
+        });
+      }
+    }, [toolbarOrientation, toolbarPosition, isCompareMode]);
+
+    // 同步外部 props - 只在值真正变化时更新
+    useLayoutEffect(() => {
+      const newPan = panOffset ?? DEFAULT_PAN;
+      latestPanOffsetRef.current = panOffset;
+      setLocalPan((prev) => {
+        if (prev.x === newPan.x && prev.y === newPan.y) return prev;
+        return newPan;
+      });
+    }, [panOffset]);
+
+    useLayoutEffect(() => {
+      latestZoomLevelRef.current = zoomLevel;
+      localZoomRef.current = zoomLevel;
+      setLocalZoom((prev) => (prev === zoomLevel ? prev : zoomLevel));
+    }, [zoomLevel]);
+
+    const applyZoom = useCallback(
+      (nextZoom: number, source: 'auto' | 'manual' = 'manual') => {
+        const clampedZoom = clampZoomLevel(nextZoom);
+        if (source === 'manual') {
+          hasManualViewChangeRef.current = true;
+        }
+        if (Math.abs(localZoomRef.current - clampedZoom) <= ZOOM_EPSILON) {
+          return;
+        }
+        localZoomRef.current = clampedZoom;
+        setLocalZoom((prev) =>
+          Math.abs(prev - clampedZoom) <= ZOOM_EPSILON ? prev : clampedZoom
+        );
+        onZoomChange?.(clampedZoom);
+      },
+      [onZoomChange]
+    );
+
+    const applyAutoPan = useCallback(
+      (nextPan: { x: number; y: number }) => {
+        const currentPan = latestPanOffsetRef.current ?? DEFAULT_PAN;
+        if (
+          Math.abs(currentPan.x - nextPan.x) <= ZOOM_EPSILON &&
+          Math.abs(currentPan.y - nextPan.y) <= ZOOM_EPSILON
+        ) {
+          return;
+        }
+        latestPanOffsetRef.current = nextPan;
+        setLocalPan(nextPan);
+        onPanChange?.(nextPan);
+      },
+      [onPanChange]
+    );
+
+    const scheduleAutoFit = useCallback(() => {
+      if (isCompareMode || isAudio || !containerRef.current) {
         return;
       }
-      localZoomRef.current = clampedZoom;
-      setLocalZoom((prev) =>
-        Math.abs(prev - clampedZoom) <= ZOOM_EPSILON ? prev : clampedZoom
-      );
-      onZoomChange?.(clampedZoom);
-    },
-    [onZoomChange]
-  );
 
-  const applyAutoPan = useCallback(
-    (nextPan: { x: number; y: number }) => {
-      const currentPan = latestPanOffsetRef.current ?? DEFAULT_PAN;
+      if (hasManualViewChangeRef.current) {
+        setIsAutoFitReady(true);
+        return;
+      }
+
+      const mediaElement = isVideo ? videoRef.current : imageRef.current;
+      if (!mediaElement || !containerRef.current) {
+        return;
+      }
+
+      const containerRect = containerRef.current.getBoundingClientRect();
+      if (containerRect.width <= 0 || containerRect.height <= 0) {
+        return;
+      }
+
+      const intrinsicWidth = isVideo
+        ? (mediaElement as HTMLVideoElement).videoWidth
+        : (mediaElement as HTMLImageElement).naturalWidth;
+      const intrinsicHeight = isVideo
+        ? (mediaElement as HTMLVideoElement).videoHeight
+        : (mediaElement as HTMLImageElement).naturalHeight;
+      if (intrinsicWidth <= 0 || intrinsicHeight <= 0) {
+        return;
+      }
+
+      const renderedSize = getBaseRenderedSize(
+        mediaElement,
+        localZoomRef.current
+      );
+      if (renderedSize.width <= 0 || renderedSize.height <= 0) {
+        return;
+      }
+
+      const verticalReserve = isVideo
+        ? VIDEO_VERTICAL_RESERVE
+        : IMAGE_VERTICAL_RESERVE;
+      const availableWidth = Math.max(
+        containerRect.width - VIEWPORT_HORIZONTAL_PADDING,
+        0
+      );
+      const availableHeight = Math.max(
+        containerRect.height - verticalReserve,
+        0
+      );
+      if (availableWidth <= 0 || availableHeight <= 0) {
+        return;
+      }
+
+      const fittedZoom = Math.min(
+        availableWidth / renderedSize.width,
+        availableHeight / renderedSize.height
+      );
+
+      if (!Number.isFinite(fittedZoom) || fittedZoom <= 0) {
+        return;
+      }
+
+      applyAutoPan({ x: 0, y: -verticalReserve / 2 });
+      applyZoom(fittedZoom, 'auto');
+      setIsAutoFitReady(true);
+    }, [isCompareMode, isAudio, isVideo, applyAutoPan, applyZoom]);
+
+    useLayoutEffect(() => {
+      if (!item?.url || isAudio || isCompareMode) {
+        return;
+      }
+
+      const mediaElement = isVideo ? videoRef.current : imageRef.current;
+      if (!mediaElement) {
+        return;
+      }
+
+      if (isVideo) {
+        const video = mediaElement as HTMLVideoElement;
+        if (video.readyState >= 1) {
+          scheduleAutoFit();
+        }
+        return;
+      }
+
+      const image = mediaElement as HTMLImageElement;
+      if (image.complete && image.naturalWidth > 0) {
+        scheduleAutoFit();
+      }
+    }, [item, isAudio, isCompareMode, isVideo, scheduleAutoFit]);
+
+    useEffect(() => {
       if (
-        Math.abs(currentPan.x - nextPan.x) <= ZOOM_EPSILON &&
-        Math.abs(currentPan.y - nextPan.y) <= ZOOM_EPSILON
+        !item?.url ||
+        isAudio ||
+        isCompareMode ||
+        typeof ResizeObserver === 'undefined' ||
+        !containerRef.current
       ) {
         return;
       }
-      latestPanOffsetRef.current = nextPan;
-      setLocalPan(nextPan);
-      onPanChange?.(nextPan);
-    },
-    [onPanChange]
-  );
 
-  const scheduleAutoFit = useCallback(() => {
-    if (
-      isCompareMode ||
-      isAudio ||
-      !containerRef.current
-    ) {
-      return;
-    }
-
-    if (hasManualViewChangeRef.current) {
-      setIsAutoFitReady(true);
-      return;
-    }
-
-    const mediaElement = isVideo ? videoRef.current : imageRef.current;
-    if (!mediaElement || !containerRef.current) {
-      return;
-    }
-
-    const containerRect = containerRef.current.getBoundingClientRect();
-    if (containerRect.width <= 0 || containerRect.height <= 0) {
-      return;
-    }
-
-    const intrinsicWidth = isVideo
-      ? (mediaElement as HTMLVideoElement).videoWidth
-      : (mediaElement as HTMLImageElement).naturalWidth;
-    const intrinsicHeight = isVideo
-      ? (mediaElement as HTMLVideoElement).videoHeight
-      : (mediaElement as HTMLImageElement).naturalHeight;
-    if (intrinsicWidth <= 0 || intrinsicHeight <= 0) {
-      return;
-    }
-
-    const renderedSize = getBaseRenderedSize(mediaElement, localZoomRef.current);
-    if (renderedSize.width <= 0 || renderedSize.height <= 0) {
-      return;
-    }
-
-    const verticalReserve = isVideo ? VIDEO_VERTICAL_RESERVE : IMAGE_VERTICAL_RESERVE;
-    const availableWidth = Math.max(containerRect.width - VIEWPORT_HORIZONTAL_PADDING, 0);
-    const availableHeight = Math.max(containerRect.height - verticalReserve, 0);
-    if (availableWidth <= 0 || availableHeight <= 0) {
-      return;
-    }
-
-    const fittedZoom = Math.min(
-      availableWidth / renderedSize.width,
-      availableHeight / renderedSize.height
-    );
-
-    if (!Number.isFinite(fittedZoom) || fittedZoom <= 0) {
-      return;
-    }
-
-    applyAutoPan({ x: 0, y: -verticalReserve / 2 });
-    applyZoom(fittedZoom, 'auto');
-    setIsAutoFitReady(true);
-  }, [isCompareMode, isAudio, isVideo, applyAutoPan, applyZoom]);
-
-  useLayoutEffect(() => {
-    if (!item?.url || isAudio || isCompareMode) {
-      return;
-    }
-
-    const mediaElement = isVideo ? videoRef.current : imageRef.current;
-    if (!mediaElement) {
-      return;
-    }
-
-    if (isVideo) {
-      const video = mediaElement as HTMLVideoElement;
-      if (video.readyState >= 1) {
+      const observer = new ResizeObserver(() => {
         scheduleAutoFit();
-      }
-      return;
-    }
+      });
+      observer.observe(containerRef.current);
 
-    const image = mediaElement as HTMLImageElement;
-    if (image.complete && image.naturalWidth > 0) {
-      scheduleAutoFit();
-    }
-  }, [item, isAudio, isCompareMode, isVideo, scheduleAutoFit]);
-
-  useEffect(() => {
-    if (
-      !item?.url ||
-      isAudio ||
-      isCompareMode ||
-      typeof ResizeObserver === 'undefined' ||
-      !containerRef.current
-    ) {
-      return;
-    }
-
-    const observer = new ResizeObserver(() => {
-      scheduleAutoFit();
-    });
-    observer.observe(containerRef.current);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [item?.url, isAudio, isCompareMode, scheduleAutoFit]);
-
-  // 鼠标拖拽
-  const handleMouseDown = useCallback(
-    (e: React.MouseEvent) => {
-      if (e.button !== 0) return;
-      e.preventDefault();
-      setIsDragging(true);
-      setDragStart({ x: e.clientX - localPan.x, y: e.clientY - localPan.y });
-    },
-    [localPan]
-  );
-
-  const handleMouseMove = useCallback(
-    (e: React.MouseEvent) => {
-      if (!isDragging) return;
-      hasManualViewChangeRef.current = true;
-      const newPan = {
-        x: e.clientX - dragStart.x,
-        y: e.clientY - dragStart.y,
+      return () => {
+        observer.disconnect();
       };
-      latestPanOffsetRef.current = newPan;
-      setLocalPan(newPan);
-      onPanChange?.(newPan);
-    },
-    [isDragging, dragStart, onPanChange]
-  );
+    }, [item?.url, isAudio, isCompareMode, scheduleAutoFit]);
 
-  const handleMouseUp = useCallback(() => {
-    setIsDragging(false);
-  }, []);
-
-  // 滚轮缩放
-  const handleWheel = useCallback(
-    (e: React.WheelEvent) => {
-      e.preventDefault();
-      const normalizedDeltaY = normalizeWheelDeltaY(e);
-      if (!Number.isFinite(normalizedDeltaY) || normalizedDeltaY === 0) {
-        return;
-      }
-      const zoomDelta = clampWheelZoomDelta(
-        -normalizedDeltaY * WHEEL_ZOOM_SENSITIVITY
-      );
-      applyZoom(localZoomRef.current + zoomDelta);
-    },
-    [applyZoom]
-  );
-
-  // 缩放控制
-  const handleZoomIn = useCallback(() => {
-    applyZoom(localZoomRef.current + TOOLBAR_ZOOM_STEP);
-  }, [applyZoom]);
-
-  const handleZoomOut = useCallback(() => {
-    applyZoom(localZoomRef.current - TOOLBAR_ZOOM_STEP);
-  }, [applyZoom]);
-
-  // 旋转控制
-  const handleRotateLeft = useCallback(() => {
-    setRotation((prev) => prev - 90);
-  }, []);
-
-  const handleRotateRight = useCallback(() => {
-    setRotation((prev) => prev + 90);
-  }, []);
-
-  // 翻转控制
-  const handleFlipHorizontal = useCallback(() => {
-    setFlipH((prev) => !prev);
-  }, []);
-
-  const handleFlipVertical = useCallback(() => {
-    setFlipV((prev) => !prev);
-  }, []);
-
-  // 插入到画布（使用全局 quickInsert，无需 board 依赖）
-  const handleInternalInsertToCanvas = useCallback(async () => {
-    if (!item) return;
-    
-    try {
-      const contentType = item.type === 'video' ? 'video' : 'image';
-      if (item.type === 'audio') {
-        MessagePlugin.warning('音频暂不支持直接插入到画布');
-        return;
-      }
-      const prompt = item.prompt?.trim();
-      const generationTaskId = item.generationTaskId?.trim();
-      const result = await quickInsertCanvasMedia(
-        contentType,
-        mediaUrl,
-        undefined,
-        undefined,
-        prompt || generationTaskId
-          ? {
-              ...(prompt ? { prompt } : {}),
-              ...(generationTaskId ? { generationTaskId } : {}),
-            }
-          : undefined
-      );
-      if (result.success) {
-        MessagePlugin.success(item.type === 'video' ? '视频已插入到画布' : '图片已插入到画布');
-      } else {
-        MessagePlugin.error(result.error || '插入失败');
-      }
-    } catch (error) {
-      console.error('Failed to insert to canvas:', error);
-      MessagePlugin.error('插入失败');
-    }
-  }, [item, mediaUrl]);
-
-  // 工具栏方向切换
-  const toggleToolbarOrientation = useCallback(() => {
-    setToolbarOrientation((prev) =>
-      prev === 'horizontal' ? 'vertical' : 'horizontal'
+    // 鼠标拖拽
+    const handleMouseDown = useCallback(
+      (e: React.MouseEvent) => {
+        if (e.button !== 0) return;
+        e.preventDefault();
+        setIsDragging(true);
+        setDragStart({ x: e.clientX - localPan.x, y: e.clientY - localPan.y });
+      },
+      [localPan]
     );
-  }, []);
 
-  // 工具栏拖拽开始 - 鼠标事件
-  const handleToolbarDragStart = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-      setIsToolbarDragging(true);
+    const handleMouseMove = useCallback(
+      (e: React.MouseEvent) => {
+        if (!isDragging) return;
+        hasManualViewChangeRef.current = true;
+        const newPan = {
+          x: e.clientX - dragStart.x,
+          y: e.clientY - dragStart.y,
+        };
+        latestPanOffsetRef.current = newPan;
+        setLocalPan(newPan);
+        onPanChange?.(newPan);
+      },
+      [isDragging, dragStart, onPanChange]
+    );
 
-      const currentPos = toolbarPosition || { x: 0, y: 0 };
-      toolbarDragStartRef.current = {
-        x: e.clientX,
-        y: e.clientY,
-        posX: currentPos.x,
-        posY: currentPos.y,
-      };
+    const handleMouseUp = useCallback(() => {
+      setIsDragging(false);
+    }, []);
 
-      const handleMouseMove = (moveEvent: MouseEvent) => {
-        const deltaX = moveEvent.clientX - toolbarDragStartRef.current.x;
-        const deltaY = moveEvent.clientY - toolbarDragStartRef.current.y;
-        setToolbarPosition({
-          x: toolbarDragStartRef.current.posX + deltaX,
-          y: toolbarDragStartRef.current.posY + deltaY,
+    // 滚轮缩放
+    const handleWheel = useCallback(
+      (e: React.WheelEvent) => {
+        e.preventDefault();
+        const normalizedDeltaY = normalizeWheelDeltaY(e);
+        if (!Number.isFinite(normalizedDeltaY) || normalizedDeltaY === 0) {
+          return;
+        }
+        const zoomDelta = clampWheelZoomDelta(
+          -normalizedDeltaY * WHEEL_ZOOM_SENSITIVITY
+        );
+        applyZoom(localZoomRef.current + zoomDelta);
+      },
+      [applyZoom]
+    );
+
+    // 缩放控制
+    const handleZoomIn = useCallback(() => {
+      applyZoom(localZoomRef.current + TOOLBAR_ZOOM_STEP);
+    }, [applyZoom]);
+
+    const handleZoomOut = useCallback(() => {
+      applyZoom(localZoomRef.current - TOOLBAR_ZOOM_STEP);
+    }, [applyZoom]);
+
+    // 旋转控制
+    const handleRotateLeft = useCallback(() => {
+      setRotation((prev) => prev - 90);
+    }, []);
+
+    const handleRotateRight = useCallback(() => {
+      setRotation((prev) => prev + 90);
+    }, []);
+
+    // 翻转控制
+    const handleFlipHorizontal = useCallback(() => {
+      setFlipH((prev) => !prev);
+    }, []);
+
+    const handleFlipVertical = useCallback(() => {
+      setFlipV((prev) => !prev);
+    }, []);
+
+    // 插入到画布（使用全局 quickInsert，无需 board 依赖）
+    const handleInternalInsertToCanvas = useCallback(async () => {
+      if (!item) return;
+
+      try {
+        const contentType = item.type === 'video' ? 'video' : 'image';
+        if (item.type === 'audio') {
+          MessagePlugin.warning('音频暂不支持直接插入到画布');
+          return;
+        }
+        const prompt = item.prompt?.trim();
+        const generationTaskId = item.generationTaskId?.trim();
+        const result = await quickInsertCanvasMedia(
+          contentType,
+          mediaUrl,
+          undefined,
+          undefined,
+          prompt || generationTaskId
+            ? {
+                ...(prompt ? { prompt } : {}),
+                ...(generationTaskId ? { generationTaskId } : {}),
+              }
+            : undefined
+        );
+        if (result.success) {
+          MessagePlugin.success(
+            item.type === 'video' ? '视频已插入到画布' : '图片已插入到画布'
+          );
+        } else {
+          MessagePlugin.error(result.error || '插入失败');
+        }
+      } catch (error) {
+        console.error('Failed to insert to canvas:', error);
+        MessagePlugin.error('插入失败');
+      }
+    }, [item, mediaUrl]);
+
+    // 工具栏方向切换
+    const toggleToolbarOrientation = useCallback(() => {
+      setToolbarOrientation((prev) =>
+        prev === 'horizontal' ? 'vertical' : 'horizontal'
+      );
+    }, []);
+
+    // 工具栏拖拽开始 - 鼠标事件
+    const handleToolbarDragStart = useCallback(
+      (e: React.MouseEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setIsToolbarDragging(true);
+
+        const currentPos = toolbarPosition || { x: 0, y: 0 };
+        toolbarDragStartRef.current = {
+          x: e.clientX,
+          y: e.clientY,
+          posX: currentPos.x,
+          posY: currentPos.y,
+        };
+
+        const handleMouseMove = (moveEvent: MouseEvent) => {
+          const deltaX = moveEvent.clientX - toolbarDragStartRef.current.x;
+          const deltaY = moveEvent.clientY - toolbarDragStartRef.current.y;
+          setToolbarPosition({
+            x: toolbarDragStartRef.current.posX + deltaX,
+            y: toolbarDragStartRef.current.posY + deltaY,
+          });
+        };
+
+        const handleMouseUp = () => {
+          setIsToolbarDragging(false);
+          document.removeEventListener('mousemove', handleMouseMove);
+          document.removeEventListener('mouseup', handleMouseUp);
+        };
+
+        document.addEventListener('mousemove', handleMouseMove);
+        document.addEventListener('mouseup', handleMouseUp);
+      },
+      [toolbarPosition]
+    );
+
+    // 工具栏拖拽开始 - 触摸事件
+    const handleToolbarTouchStart = useCallback(
+      (e: React.TouchEvent) => {
+        e.stopPropagation();
+        if (e.touches.length !== 1) return;
+
+        const touch = e.touches[0];
+        setIsToolbarDragging(true);
+
+        const currentPos = toolbarPosition || { x: 0, y: 0 };
+        toolbarDragStartRef.current = {
+          x: touch.clientX,
+          y: touch.clientY,
+          posX: currentPos.x,
+          posY: currentPos.y,
+        };
+
+        const handleTouchMove = (moveEvent: TouchEvent) => {
+          if (moveEvent.touches.length !== 1) return;
+          moveEvent.preventDefault();
+          const moveTouch = moveEvent.touches[0];
+          const deltaX = moveTouch.clientX - toolbarDragStartRef.current.x;
+          const deltaY = moveTouch.clientY - toolbarDragStartRef.current.y;
+          setToolbarPosition({
+            x: toolbarDragStartRef.current.posX + deltaX,
+            y: toolbarDragStartRef.current.posY + deltaY,
+          });
+        };
+
+        const handleTouchEnd = () => {
+          setIsToolbarDragging(false);
+          document.removeEventListener('touchmove', handleTouchMove);
+          document.removeEventListener('touchend', handleTouchEnd);
+          document.removeEventListener('touchcancel', handleTouchEnd);
+        };
+
+        document.addEventListener('touchmove', handleTouchMove, {
+          passive: false,
         });
-      };
+        document.addEventListener('touchend', handleTouchEnd);
+        document.addEventListener('touchcancel', handleTouchEnd);
+      },
+      [toolbarPosition]
+    );
 
-      const handleMouseUp = () => {
-        setIsToolbarDragging(false);
-        document.removeEventListener('mousemove', handleMouseMove);
-        document.removeEventListener('mouseup', handleMouseUp);
-      };
+    // 重置工具栏位置
+    const resetToolbarPosition = useCallback(() => {
+      setToolbarPosition(null);
+    }, []);
 
-      document.addEventListener('mousemove', handleMouseMove);
-      document.addEventListener('mouseup', handleMouseUp);
-    },
-    [toolbarPosition]
-  );
+    if (!item) {
+      return (
+        <div
+          className={`media-viewport media-viewport--empty ${
+            isFocused ? 'media-viewport--focused' : ''
+          }`}
+          onClick={onClick}
+        >
+          <div className="media-viewport__placeholder">
+            <span>点击底部缩略图添加媒体</span>
+          </div>
+        </div>
+      );
+    }
 
-  // 工具栏拖拽开始 - 触摸事件
-  const handleToolbarTouchStart = useCallback(
-    (e: React.TouchEvent) => {
-      e.stopPropagation();
-      if (e.touches.length !== 1) return;
+    const scaleX = flipH ? -localZoom : localZoom;
+    const scaleY = flipV ? -localZoom : localZoom;
+    const transformStyle = {
+      transform: `translate(${localPan.x}px, ${localPan.y}px) scale(${scaleX}, ${scaleY}) rotate(${rotation}deg)`,
+    };
+    const shouldHideUntilAutoFit = needsAutoFitGate && !isAutoFitReady;
 
-      const touch = e.touches[0];
-      setIsToolbarDragging(true);
-
-      const currentPos = toolbarPosition || { x: 0, y: 0 };
-      toolbarDragStartRef.current = {
-        x: touch.clientX,
-        y: touch.clientY,
-        posX: currentPos.x,
-        posY: currentPos.y,
-      };
-
-      const handleTouchMove = (moveEvent: TouchEvent) => {
-        if (moveEvent.touches.length !== 1) return;
-        moveEvent.preventDefault();
-        const moveTouch = moveEvent.touches[0];
-        const deltaX = moveTouch.clientX - toolbarDragStartRef.current.x;
-        const deltaY = moveTouch.clientY - toolbarDragStartRef.current.y;
-        setToolbarPosition({
-          x: toolbarDragStartRef.current.posX + deltaX,
-          y: toolbarDragStartRef.current.posY + deltaY,
-        });
-      };
-
-      const handleTouchEnd = () => {
-        setIsToolbarDragging(false);
-        document.removeEventListener('touchmove', handleTouchMove);
-        document.removeEventListener('touchend', handleTouchEnd);
-        document.removeEventListener('touchcancel', handleTouchEnd);
-      };
-
-      document.addEventListener('touchmove', handleTouchMove, { passive: false });
-      document.addEventListener('touchend', handleTouchEnd);
-      document.addEventListener('touchcancel', handleTouchEnd);
-    },
-    [toolbarPosition]
-  );
-
-  // 重置工具栏位置
-  const resetToolbarPosition = useCallback(() => {
-    setToolbarPosition(null);
-  }, []);
-
-  if (!item) {
     return (
       <div
-        className={`media-viewport media-viewport--empty ${isFocused ? 'media-viewport--focused' : ''}`}
+        ref={containerRef}
+        className={`media-viewport ${
+          isFocused ? 'media-viewport--focused' : ''
+        } ${isAudio ? 'media-viewport--audio' : ''} ${
+          isVideo ? 'media-viewport--video' : ''
+        } ${!isCompareMode ? 'media-viewport--single' : ''}`}
         onClick={onClick}
+        onMouseDown={isAudio ? undefined : handleMouseDown}
+        onMouseMove={isAudio ? undefined : handleMouseMove}
+        onMouseUp={isAudio ? undefined : handleMouseUp}
+        onWheel={isAudio ? undefined : handleWheel}
+        onMouseLeave={() => {
+          if (!isAudio) {
+            handleMouseUp();
+          }
+          setIsMediaHovered(false);
+          setIsPromptHovered(false);
+          setIsToolbarHovered(false);
+          clearPromptHideTimer();
+        }}
+        data-slot={slotIndex}
       >
-        <div className="media-viewport__placeholder">
-          <span>点击底部缩略图添加媒体</span>
+        {/* 媒体内容 */}
+        <div
+          className={`media-viewport__content ${
+            shouldHideUntilAutoFit
+              ? 'media-viewport__content--auto-fitting'
+              : ''
+          }`}
+          style={isAudio ? undefined : transformStyle}
+        >
+          {isMediaUrlLoading && (isVideo || isAudio) ? (
+            <div className="media-viewport__image-fallback">
+              <span>正在读取本地媒体...</span>
+            </div>
+          ) : !mediaUrl && (isVideo || isAudio) ? (
+            <div className="media-viewport__image-fallback">
+              <span>本地媒体缓存不可用，请重新生成</span>
+            </div>
+          ) : isVideo ? (
+            <div
+              className="media-viewport__media-hitbox"
+              onMouseEnter={handleMediaHoverStart}
+              onMouseLeave={handleMediaHoverEnd}
+            >
+              <video
+                ref={videoRef}
+                src={mediaUrl}
+                autoPlay={videoAutoPlay}
+                loop={videoLoop}
+                controls
+                className="media-viewport__video"
+                // @ts-expect-error -- React types lack referrerPolicy on <video>
+                referrerPolicy="no-referrer"
+                onClick={(e) => e.stopPropagation()}
+                onPlay={() => {
+                  if (isSyncMode && onVideoPlayStateChange) {
+                    onVideoPlayStateChange(true);
+                  }
+                }}
+                onPause={() => {
+                  if (isSyncMode && onVideoPlayStateChange) {
+                    onVideoPlayStateChange(false);
+                  }
+                }}
+                onSeeked={() => {
+                  if (isSyncMode && onVideoTimeUpdate && videoRef.current) {
+                    onVideoTimeUpdate(videoRef.current.currentTime);
+                  }
+                }}
+                onLoadedMetadata={scheduleAutoFit}
+              />
+            </div>
+          ) : isAudio ? (
+            <div
+              className="media-viewport__audio-shell"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="media-viewport__audio-card">
+                <AudioCover
+                  src={posterUrl}
+                  alt={item.alt || item.title || ''}
+                  imageClassName="media-viewport__audio-poster"
+                  fallbackClassName="media-viewport__audio-poster media-viewport__audio-poster--fallback"
+                  iconSize={56}
+                />
+                <div className="media-viewport__audio-meta">
+                  {item.title && (
+                    <div className="media-viewport__audio-title">
+                      {item.title}
+                    </div>
+                  )}
+                  {typeof item.duration === 'number' &&
+                    Number.isFinite(item.duration) &&
+                    item.duration > 0 && (
+                      <div className="media-viewport__audio-duration">
+                        {Math.floor(item.duration / 60)}:
+                        {String(Math.round(item.duration % 60)).padStart(
+                          2,
+                          '0'
+                        )}
+                      </div>
+                    )}
+                </div>
+                <audio
+                  src={mediaUrl}
+                  controls
+                  preload="metadata"
+                  className="media-viewport__audio"
+                  // @ts-expect-error -- React types lack referrerPolicy on <audio>
+                  referrerPolicy="no-referrer"
+                />
+              </div>
+            </div>
+          ) : imageLoadFailed ? (
+            <div
+              className="media-viewport__media-hitbox"
+              onMouseEnter={handleMediaHoverStart}
+              onMouseLeave={handleMediaHoverEnd}
+            >
+              <div className="media-viewport__image-fallback">
+                <span>图片加载失败</span>
+              </div>
+            </div>
+          ) : (
+            <div
+              className="media-viewport__media-hitbox"
+              onMouseEnter={handleMediaHoverStart}
+              onMouseLeave={handleMediaHoverEnd}
+            >
+              <RetryImage
+                ref={imageRef}
+                src={mediaUrl}
+                alt={item.alt || item.title || ''}
+                className="media-viewport__image"
+                draggable={false}
+                showSkeleton={false}
+                eager
+                onLoad={scheduleAutoFit}
+                onError={() => {
+                  setImageLoadFailed(true);
+                  setIsAutoFitReady(true);
+                }}
+              />
+            </div>
+          )}
         </div>
+
+        {/* 工具控制栏 */}
+        <div
+          className={`media-viewport__toolbar media-viewport__toolbar--${toolbarOrientation} ${
+            isToolbarDragging ? 'media-viewport__toolbar--dragging' : ''
+          } ${isCompareMode ? 'media-viewport__toolbar--compact' : ''}`}
+          style={
+            !isCompareMode && toolbarPosition
+              ? {
+                  transform: `translate(calc(-50% + ${toolbarPosition.x}px), ${toolbarPosition.y}px)`,
+                }
+              : undefined
+          }
+          onMouseEnter={() => setIsToolbarHovered(true)}
+          onMouseLeave={() => setIsToolbarHovered(false)}
+          onMouseDown={(e) => e.stopPropagation()}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {!isAudio && (
+            <>
+              {/* 拖拽手柄 + 方向切换 - 仅单图模式 */}
+              {!isCompareMode && (
+                <>
+                  <HoverPopover
+                    content="拖拽移动工具栏，双击重置位置"
+                    placement="top"
+                    contentClassName="viewer-popover"
+                  >
+                    <div
+                      className="media-viewport__toolbar-handle"
+                      onMouseDown={handleToolbarDragStart}
+                      onTouchStart={handleToolbarTouchStart}
+                      onDoubleClick={(e) => {
+                        e.stopPropagation();
+                        resetToolbarPosition();
+                      }}
+                    >
+                      <GripHorizontal size={14} />
+                    </div>
+                  </HoverPopover>
+                  <HoverPopover
+                    content={
+                      toolbarOrientation === 'horizontal'
+                        ? '切换为垂直布局'
+                        : '切换为水平布局'
+                    }
+                    placement="top"
+                    contentClassName="viewer-popover"
+                  >
+                    <button
+                      type="button"
+                      className="media-viewport__toolbar-orientation-btn"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        e.preventDefault();
+                        toggleToolbarOrientation();
+                      }}
+                    >
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        {toolbarOrientation === 'horizontal' ? (
+                          <>
+                            <line x1="12" y1="3" x2="12" y2="21" />
+                            <polyline points="8 7 12 3 16 7" />
+                            <polyline points="8 17 12 21 16 17" />
+                          </>
+                        ) : (
+                          <>
+                            <line x1="3" y1="12" x2="21" y2="12" />
+                            <polyline points="7 8 3 12 7 16" />
+                            <polyline points="17 8 21 12 17 16" />
+                          </>
+                        )}
+                      </svg>
+                    </button>
+                  </HoverPopover>
+                  <div className="media-viewport__toolbar-divider" />
+                </>
+              )}
+
+              {/* 缩放控制 */}
+              <div className="media-viewport__toolbar-group">
+                <HoverPopover
+                  content="缩小"
+                  placement="top"
+                  contentClassName="viewer-popover"
+                >
+                  <button
+                    type="button"
+                    aria-label="缩小"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      e.preventDefault();
+                      handleZoomOut();
+                    }}
+                  >
+                    <ZoomOut size={16} />
+                  </button>
+                </HoverPopover>
+                <span className="media-viewport__zoom-level">
+                  {Math.round(localZoom * 100)}%
+                </span>
+                <HoverPopover
+                  content="放大"
+                  placement="top"
+                  contentClassName="viewer-popover"
+                >
+                  <button
+                    type="button"
+                    aria-label="放大"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      e.preventDefault();
+                      handleZoomIn();
+                    }}
+                  >
+                    <ZoomIn size={16} />
+                  </button>
+                </HoverPopover>
+              </div>
+
+              <div className="media-viewport__toolbar-divider" />
+
+              {dimensionsLabel && (
+                <>
+                  <span
+                    className="media-viewport__dimensions"
+                    aria-label={`图片尺寸 ${dimensionsLabel} 像素`}
+                  >
+                    {dimensionsLabel}
+                  </span>
+                  <div className="media-viewport__toolbar-divider" />
+                </>
+              )}
+
+              {/* 旋转控制 */}
+              <div className="media-viewport__toolbar-group">
+                <HoverPopover
+                  content="向左旋转 90°"
+                  placement="top"
+                  contentClassName="viewer-popover"
+                >
+                  <button
+                    type="button"
+                    aria-label="向左旋转 90°"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      e.preventDefault();
+                      handleRotateLeft();
+                    }}
+                  >
+                    <RotateCcw size={16} />
+                  </button>
+                </HoverPopover>
+                <HoverPopover
+                  content="向右旋转 90°"
+                  placement="top"
+                  contentClassName="viewer-popover"
+                >
+                  <button
+                    type="button"
+                    aria-label="向右旋转 90°"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      e.preventDefault();
+                      handleRotateRight();
+                    }}
+                  >
+                    <RotateCw size={16} />
+                  </button>
+                </HoverPopover>
+              </div>
+
+              <div className="media-viewport__toolbar-divider" />
+
+              {/* 翻转控制 */}
+              <div className="media-viewport__toolbar-group">
+                <HoverPopover
+                  content="水平翻转"
+                  placement="top"
+                  contentClassName="viewer-popover"
+                >
+                  <button
+                    type="button"
+                    aria-label="水平翻转"
+                    className={flipH ? 'active' : ''}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      e.preventDefault();
+                      handleFlipHorizontal();
+                    }}
+                  >
+                    <FlipHorizontal size={16} />
+                  </button>
+                </HoverPopover>
+                <HoverPopover
+                  content="垂直翻转"
+                  placement="top"
+                  contentClassName="viewer-popover"
+                >
+                  <button
+                    type="button"
+                    aria-label="垂直翻转"
+                    className={flipV ? 'active' : ''}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      e.preventDefault();
+                      handleFlipVertical();
+                    }}
+                  >
+                    <FlipVertical size={16} />
+                  </button>
+                </HoverPopover>
+              </div>
+            </>
+          )}
+
+          {/* 插入到画布 - 仅单图模式（使用内部 quickInsert，无需外部依赖） */}
+          {!isCompareMode && !isAudio && (
+            <>
+              <div className="media-viewport__toolbar-divider" />
+              <HoverPopover
+                content="插入到画布"
+                placement="top"
+                contentClassName="viewer-popover"
+              >
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    // 优先使用外部回调（如果有），否则使用内部 quickInsert
+                    if (onInsertToCanvas) {
+                      onInsertToCanvas();
+                    } else {
+                      handleInternalInsertToCanvas();
+                    }
+                  }}
+                >
+                  <Plus size={16} />
+                </button>
+              </HoverPopover>
+            </>
+          )}
+
+          {/* 下载 - 仅单图模式 */}
+          {!isCompareMode && onDownload && (
+            <>
+              {isAudio && <div className="media-viewport__toolbar-divider" />}
+              <HoverPopover
+                content="下载"
+                placement="top"
+                contentClassName="viewer-popover"
+              >
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    onDownload();
+                  }}
+                >
+                  <Download size={16} />
+                </button>
+              </HoverPopover>
+            </>
+          )}
+
+          {!isCompareMode && isAudio && (
+            <HoverPopover
+              content="打开原始链接"
+              placement="top"
+              contentClassName="viewer-popover"
+            >
+              <button
+                type="button"
+                aria-label="打开原始音频链接"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  event.preventDefault();
+                  window.open(item.url, '_blank', 'noopener,noreferrer');
+                }}
+              >
+                <ExternalLink size={16} />
+              </button>
+            </HoverPopover>
+          )}
+
+          {/* 编辑 - 仅单图模式且为图片 */}
+          {!isCompareMode && onEdit && item?.type === 'image' && (
+            <HoverPopover
+              content="编辑图片"
+              placement="top"
+              contentClassName="viewer-popover"
+            >
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  onEdit();
+                }}
+              >
+                <Pencil size={16} />
+              </button>
+            </HoverPopover>
+          )}
+        </div>
+
+        {/* 提示词 */}
+        {promptText && !isAudio && (
+          <HoverPopover
+            content={promptText}
+            placement="bottom"
+            sideOffset={10}
+            contentClassName="viewer-popover viewer-popover--prompt"
+          >
+            <div
+              className={`media-viewport__prompt ${
+                showPrompt ? 'media-viewport__prompt--visible' : ''
+              } ${isPromptHovered ? 'media-viewport__prompt--expanded' : ''}`}
+              onMouseEnter={handlePromptHoverStart}
+              onMouseLeave={handlePromptHoverEnd}
+            >
+              {promptText}
+            </div>
+          </HoverPopover>
+        )}
       </div>
     );
   }
-
-  const scaleX = flipH ? -localZoom : localZoom;
-  const scaleY = flipV ? -localZoom : localZoom;
-  const transformStyle = {
-    transform: `translate(${localPan.x}px, ${localPan.y}px) scale(${scaleX}, ${scaleY}) rotate(${rotation}deg)`,
-  };
-  const shouldHideUntilAutoFit = needsAutoFitGate && !isAutoFitReady;
-
-  return (
-    <div
-      ref={containerRef}
-      className={`media-viewport ${isFocused ? 'media-viewport--focused' : ''} ${isAudio ? 'media-viewport--audio' : ''} ${isVideo ? 'media-viewport--video' : ''} ${!isCompareMode ? 'media-viewport--single' : ''}`}
-      onClick={onClick}
-      onMouseDown={isAudio ? undefined : handleMouseDown}
-      onMouseMove={isAudio ? undefined : handleMouseMove}
-      onMouseUp={isAudio ? undefined : handleMouseUp}
-      onWheel={isAudio ? undefined : handleWheel}
-      onMouseLeave={() => {
-        if (!isAudio) {
-          handleMouseUp();
-        }
-        setIsMediaHovered(false);
-        setIsPromptHovered(false);
-        setIsToolbarHovered(false);
-        clearPromptHideTimer();
-      }}
-      data-slot={slotIndex}
-    >
-      {/* 媒体内容 */}
-      <div
-        className={`media-viewport__content ${shouldHideUntilAutoFit ? 'media-viewport__content--auto-fitting' : ''}`}
-        style={isAudio ? undefined : transformStyle}
-      >
-        {isMediaUrlLoading && (isVideo || isAudio) ? (
-          <div className="media-viewport__image-fallback">
-            <span>正在读取本地媒体...</span>
-          </div>
-        ) : !mediaUrl && (isVideo || isAudio) ? (
-          <div className="media-viewport__image-fallback">
-            <span>本地媒体缓存不可用，请重新生成</span>
-          </div>
-        ) : isVideo ? (
-          <div
-            className="media-viewport__media-hitbox"
-            onMouseEnter={handleMediaHoverStart}
-            onMouseLeave={handleMediaHoverEnd}
-          >
-            <video
-              ref={videoRef}
-              src={mediaUrl}
-              autoPlay={videoAutoPlay}
-              loop={videoLoop}
-              controls
-              className="media-viewport__video"
-              // @ts-expect-error -- React types lack referrerPolicy on <video>
-              referrerPolicy="no-referrer"
-              onClick={(e) => e.stopPropagation()}
-              onPlay={() => {
-                if (isSyncMode && onVideoPlayStateChange) {
-                  onVideoPlayStateChange(true);
-                }
-              }}
-              onPause={() => {
-                if (isSyncMode && onVideoPlayStateChange) {
-                  onVideoPlayStateChange(false);
-                }
-              }}
-              onSeeked={() => {
-                if (isSyncMode && onVideoTimeUpdate && videoRef.current) {
-                  onVideoTimeUpdate(videoRef.current.currentTime);
-                }
-              }}
-              onLoadedMetadata={scheduleAutoFit}
-            />
-          </div>
-        ) : isAudio ? (
-          <div className="media-viewport__audio-shell" onClick={(e) => e.stopPropagation()}>
-            <div className="media-viewport__audio-card">
-              <AudioCover
-                src={posterUrl}
-                alt={item.alt || item.title || ''}
-                imageClassName="media-viewport__audio-poster"
-                fallbackClassName="media-viewport__audio-poster media-viewport__audio-poster--fallback"
-                iconSize={56}
-              />
-              <div className="media-viewport__audio-meta">
-                {item.title && <div className="media-viewport__audio-title">{item.title}</div>}
-                {typeof item.duration === 'number' && Number.isFinite(item.duration) && item.duration > 0 && (
-                  <div className="media-viewport__audio-duration">
-                    {Math.floor(item.duration / 60)}:{String(Math.round(item.duration % 60)).padStart(2, '0')}
-                  </div>
-                )}
-              </div>
-              <audio
-                src={mediaUrl}
-                controls
-                preload="metadata"
-                className="media-viewport__audio"
-                // @ts-expect-error -- React types lack referrerPolicy on <audio>
-                referrerPolicy="no-referrer"
-              />
-            </div>
-          </div>
-        ) : imageLoadFailed ? (
-          <div
-            className="media-viewport__media-hitbox"
-            onMouseEnter={handleMediaHoverStart}
-            onMouseLeave={handleMediaHoverEnd}
-          >
-            <div className="media-viewport__image-fallback">
-              <span>图片加载失败</span>
-            </div>
-          </div>
-        ) : (
-          <div
-            className="media-viewport__media-hitbox"
-            onMouseEnter={handleMediaHoverStart}
-            onMouseLeave={handleMediaHoverEnd}
-          >
-            <RetryImage
-              ref={imageRef}
-              src={mediaUrl}
-              alt={item.alt || item.title || ''}
-              className="media-viewport__image"
-              draggable={false}
-              showSkeleton={false}
-              eager
-              onLoad={scheduleAutoFit}
-              onError={() => {
-                setImageLoadFailed(true);
-                setIsAutoFitReady(true);
-              }}
-            />
-          </div>
-        )}
-      </div>
-
-      {/* 工具控制栏 */}
-      <div
-        className={`media-viewport__toolbar media-viewport__toolbar--${toolbarOrientation} ${
-          isToolbarDragging ? 'media-viewport__toolbar--dragging' : ''
-        } ${isCompareMode ? 'media-viewport__toolbar--compact' : ''}`}
-        style={
-          !isCompareMode && toolbarPosition
-            ? {
-                transform: `translate(calc(-50% + ${toolbarPosition.x}px), ${toolbarPosition.y}px)`,
-              }
-            : undefined
-        }
-        onMouseEnter={() => setIsToolbarHovered(true)}
-        onMouseLeave={() => setIsToolbarHovered(false)}
-        onMouseDown={(e) => e.stopPropagation()}
-        onClick={(e) => e.stopPropagation()}
-      >
-        {!isAudio && (
-          <>
-        {/* 拖拽手柄 + 方向切换 - 仅单图模式 */}
-        {!isCompareMode && (
-          <>
-            <HoverPopover
-              content="拖拽移动工具栏，双击重置位置"
-              placement="top"
-              contentClassName="viewer-popover"
-            >
-              <div
-                className="media-viewport__toolbar-handle"
-                onMouseDown={handleToolbarDragStart}
-                onTouchStart={handleToolbarTouchStart}
-                onDoubleClick={(e) => {
-                  e.stopPropagation();
-                  resetToolbarPosition();
-                }}
-              >
-                <GripHorizontal size={14} />
-              </div>
-            </HoverPopover>
-            <HoverPopover
-              content={toolbarOrientation === 'horizontal' ? '切换为垂直布局' : '切换为水平布局'}
-              placement="top"
-              contentClassName="viewer-popover"
-            >
-              <button
-                type="button"
-                className="media-viewport__toolbar-orientation-btn"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  e.preventDefault();
-                  toggleToolbarOrientation();
-                }}
-              >
-                <svg
-                  width="16"
-                  height="16"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  {toolbarOrientation === 'horizontal' ? (
-                    <>
-                      <line x1="12" y1="3" x2="12" y2="21" />
-                      <polyline points="8 7 12 3 16 7" />
-                      <polyline points="8 17 12 21 16 17" />
-                    </>
-                  ) : (
-                    <>
-                      <line x1="3" y1="12" x2="21" y2="12" />
-                      <polyline points="7 8 3 12 7 16" />
-                      <polyline points="17 8 21 12 17 16" />
-                    </>
-                  )}
-                </svg>
-              </button>
-            </HoverPopover>
-            <div className="media-viewport__toolbar-divider" />
-          </>
-        )}
-
-        {/* 缩放控制 */}
-        <div className="media-viewport__toolbar-group">
-          <HoverPopover content="缩小" placement="top" contentClassName="viewer-popover">
-            <button
-              type="button"
-              aria-label="缩小"
-              onClick={(e) => {
-                e.stopPropagation();
-                e.preventDefault();
-                handleZoomOut();
-              }}
-            >
-              <ZoomOut size={16} />
-            </button>
-          </HoverPopover>
-          <span className="media-viewport__zoom-level">
-            {Math.round(localZoom * 100)}%
-          </span>
-          <HoverPopover content="放大" placement="top" contentClassName="viewer-popover">
-            <button
-              type="button"
-              aria-label="放大"
-              onClick={(e) => {
-                e.stopPropagation();
-                e.preventDefault();
-                handleZoomIn();
-              }}
-            >
-              <ZoomIn size={16} />
-            </button>
-          </HoverPopover>
-        </div>
-
-        <div className="media-viewport__toolbar-divider" />
-
-        {dimensionsLabel && (
-          <>
-            <span
-              className="media-viewport__dimensions"
-              aria-label={`图片尺寸 ${dimensionsLabel} 像素`}
-            >
-              {dimensionsLabel}
-            </span>
-            <div className="media-viewport__toolbar-divider" />
-          </>
-        )}
-
-        {/* 旋转控制 */}
-        <div className="media-viewport__toolbar-group">
-          <HoverPopover content="向左旋转 90°" placement="top" contentClassName="viewer-popover">
-            <button
-              type="button"
-              aria-label="向左旋转 90°"
-              onClick={(e) => {
-                e.stopPropagation();
-                e.preventDefault();
-                handleRotateLeft();
-              }}
-            >
-              <RotateCcw size={16} />
-            </button>
-          </HoverPopover>
-          <HoverPopover content="向右旋转 90°" placement="top" contentClassName="viewer-popover">
-            <button
-              type="button"
-              aria-label="向右旋转 90°"
-              onClick={(e) => {
-                e.stopPropagation();
-                e.preventDefault();
-                handleRotateRight();
-              }}
-            >
-              <RotateCw size={16} />
-            </button>
-          </HoverPopover>
-        </div>
-
-        <div className="media-viewport__toolbar-divider" />
-
-        {/* 翻转控制 */}
-        <div className="media-viewport__toolbar-group">
-          <HoverPopover content="水平翻转" placement="top" contentClassName="viewer-popover">
-            <button
-              type="button"
-              aria-label="水平翻转"
-              className={flipH ? 'active' : ''}
-              onClick={(e) => {
-                e.stopPropagation();
-                e.preventDefault();
-                handleFlipHorizontal();
-              }}
-            >
-              <FlipHorizontal size={16} />
-            </button>
-          </HoverPopover>
-          <HoverPopover content="垂直翻转" placement="top" contentClassName="viewer-popover">
-            <button
-              type="button"
-              aria-label="垂直翻转"
-              className={flipV ? 'active' : ''}
-              onClick={(e) => {
-                e.stopPropagation();
-                e.preventDefault();
-                handleFlipVertical();
-              }}
-            >
-              <FlipVertical size={16} />
-            </button>
-          </HoverPopover>
-        </div>
-          </>
-        )}
-
-        {/* 插入到画布 - 仅单图模式（使用内部 quickInsert，无需外部依赖） */}
-        {!isCompareMode && !isAudio && (
-          <>
-            <div className="media-viewport__toolbar-divider" />
-            <HoverPopover
-              content="插入到画布"
-              placement="top"
-              contentClassName="viewer-popover"
-            >
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  e.preventDefault();
-                  // 优先使用外部回调（如果有），否则使用内部 quickInsert
-                  if (onInsertToCanvas) {
-                    onInsertToCanvas();
-                  } else {
-                    handleInternalInsertToCanvas();
-                  }
-                }}
-              >
-                <Plus size={16} />
-              </button>
-            </HoverPopover>
-          </>
-        )}
-
-        {/* 下载 - 仅单图模式 */}
-        {!isCompareMode && onDownload && (
-          <>
-            {isAudio && <div className="media-viewport__toolbar-divider" />}
-            <HoverPopover
-              content="下载"
-              placement="top"
-              contentClassName="viewer-popover"
-            >
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                e.preventDefault();
-                onDownload();
-              }}
-            >
-              <Download size={16} />
-            </button>
-            </HoverPopover>
-          </>
-        )}
-
-        {/* 编辑 - 仅单图模式且为图片 */}
-        {!isCompareMode && onEdit && item?.type === 'image' && (
-          <HoverPopover
-            content="编辑图片"
-            placement="top"
-            contentClassName="viewer-popover"
-          >
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                e.preventDefault();
-                onEdit();
-              }}
-            >
-              <Pencil size={16} />
-            </button>
-          </HoverPopover>
-        )}
-      </div>
-
-      {/* 提示词 */}
-      {promptText && !isAudio && (
-        <HoverPopover
-          content={promptText}
-          placement="bottom"
-          sideOffset={10}
-          contentClassName="viewer-popover viewer-popover--prompt"
-        >
-          <div
-            className={`media-viewport__prompt ${showPrompt ? 'media-viewport__prompt--visible' : ''} ${isPromptHovered ? 'media-viewport__prompt--expanded' : ''}`}
-            onMouseEnter={handlePromptHoverStart}
-            onMouseLeave={handlePromptHoverEnd}
-          >
-            {promptText}
-          </div>
-        </HoverPopover>
-      )}
-    </div>
-  );
-});
+);
 
 MediaViewport.displayName = 'MediaViewport';
 

--- a/packages/drawnix/src/components/task-queue/DialogTaskList.tsx
+++ b/packages/drawnix/src/components/task-queue/DialogTaskList.tsx
@@ -491,20 +491,9 @@ export const DialogTaskList: React.FC<DialogTaskListProps> = ({
           });
         }
       }
-
-      const taskItemCount = items.length - startIndex;
       configMap.set(task.id, {
-        mode:
-          task.type === TaskType.AUDIO && taskItemCount > 1
-            ? 'compare'
-            : 'single',
-        index:
-          task.type === TaskType.AUDIO && taskItemCount > 1
-            ? Array.from(
-                { length: Math.min(taskItemCount, 4) },
-                (_, offset) => startIndex + offset
-              )
-            : startIndex,
+        mode: 'single',
+        index: startIndex,
       });
     }
 

--- a/packages/drawnix/src/components/task-queue/TaskItem.tsx
+++ b/packages/drawnix/src/components/task-queue/TaskItem.tsx
@@ -51,6 +51,7 @@ import './task-queue.scss';
 import './task-progress-overlay.scss';
 import { HoverTip } from '../shared';
 import { isVirtualMediaUrl } from '../../utils/virtual-media-url';
+import { resolveAudioResultUrls } from '../../services/audio-task-result-utils';
 
 // 布局切换阈值：容器宽度小于此值时使用紧凑布局（info 在图片下方全宽）
 // 弹窗侧栏宽度约 280px-500px，任务队列面板宽度约 300px-600px
@@ -405,6 +406,8 @@ export const TaskItem: React.FC<TaskItemProps> = React.memo(
     // Use original URL or cached URL (Service Worker handles caching automatically)
     const mediaCount = isLyricsTask
       ? 0
+      : isAudioTask
+      ? resolveAudioResultUrls(task.result).length
       : task.result?.urls?.length || (task.result?.url ? 1 : 0);
     const actionTrackParams = useMemo(
       () =>
@@ -861,7 +864,21 @@ export const TaskItem: React.FC<TaskItemProps> = React.memo(
                   {isCompleted &&
                     task.result?.url &&
                     !isLyricsTask &&
-                    (isVirtualMediaUrl(task.result.url) ? (
+                    (isAudioTask ? (
+                      <button
+                        type="button"
+                        className="task-item__link"
+                        data-track="task_click_open_audio_results"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onPreviewOpen?.();
+                        }}
+                      >
+                        {mediaCount > 1
+                          ? ` · 查看全部 ${mediaCount} 首`
+                          : ' · 播放音频'}
+                      </button>
+                    ) : isVirtualMediaUrl(task.result.url) ? (
                       <button
                         type="button"
                         className="task-item__link"

--- a/packages/drawnix/src/components/task-queue/TaskQueuePanel.tsx
+++ b/packages/drawnix/src/components/task-queue/TaskQueuePanel.tsx
@@ -963,20 +963,9 @@ export const TaskQueuePanel: React.FC<TaskQueuePanelProps> = ({
           });
         }
       }
-
-      const taskItemCount = items.length - startIndex;
       configMap.set(task.id, {
-        mode:
-          task.type === TaskType.AUDIO && taskItemCount > 1
-            ? 'compare'
-            : 'single',
-        index:
-          task.type === TaskType.AUDIO && taskItemCount > 1
-            ? Array.from(
-                { length: Math.min(taskItemCount, 4) },
-                (_, offset) => startIndex + offset
-              )
-            : startIndex,
+        mode: 'single',
+        index: startIndex,
       });
     }
 

--- a/packages/drawnix/src/constants/model-config.ts
+++ b/packages/drawnix/src/constants/model-config.ts
@@ -1827,18 +1827,12 @@ const SEEDANCE_20_MODEL_IDS = [
   'doubao-seedance-2-0-mini-260615',
 ];
 
-const SEEDANCE_2_MODEL_IDS = [
-  ...SEEDANCE_20_MODEL_IDS,
-  SEEDANCE_25_MODEL_ID,
-];
+const SEEDANCE_2_MODEL_IDS = [...SEEDANCE_20_MODEL_IDS, SEEDANCE_25_MODEL_ID];
 
-const SEEDANCE_25_DURATION_OPTIONS = Array.from(
-  { length: 27 },
-  (_, index) => {
-    const value = String(index + 4);
-    return { value, label: `${value}秒` };
-  }
-);
+const SEEDANCE_25_DURATION_OPTIONS = Array.from({ length: 27 }, (_, index) => {
+  const value = String(index + 4);
+  return { value, label: `${value}秒` };
+});
 
 const SEEDANCE_25_RATIO_OPTIONS = [
   { value: '16:9', label: '16:9 横屏' },
@@ -2496,6 +2490,21 @@ export const AUDIO_PARAMS: ParamConfig[] = [
     shortLabel: '风格',
     description: '可选，使用逗号分隔多个风格标签',
     valueType: 'string',
+    compatibleModels: ['suno_music'],
+    compatibleTags: ['suno', 'audio', 'music'],
+    modelType: 'audio',
+  },
+  {
+    id: 'instrumental',
+    label: '纯音乐',
+    shortLabel: '纯音乐',
+    description: '只生成乐器演奏，不生成演唱人声',
+    valueType: 'enum',
+    options: [
+      { value: 'false', label: '可包含人声' },
+      { value: 'true', label: '仅纯音乐' },
+    ],
+    defaultValue: 'false',
     compatibleModels: ['suno_music'],
     compatibleTags: ['suno', 'audio', 'music'],
     modelType: 'audio',

--- a/packages/drawnix/src/mcp/tools/audio-generation.ts
+++ b/packages/drawnix/src/mcp/tools/audio-generation.ts
@@ -30,6 +30,7 @@ export interface AudioGenerationParams {
   notifyHook?: string;
   title?: string;
   tags?: string;
+  instrumental?: boolean;
   mv?: string;
   continueSource?: 'clip' | 'upload';
   continueClipId?: string;
@@ -71,6 +72,7 @@ async function executeAsync(params: AudioGenerationParams): Promise<MCPResult> {
       notifyHook: params.notifyHook,
       title: params.title,
       tags: params.tags,
+      instrumental: params.instrumental,
       mv: params.mv,
       continueClipId: params.continueClipId,
       continueTaskId: params.continueTaskId,
@@ -131,6 +133,7 @@ function getAudioQueueConfig(params: AudioGenerationParams) {
       notifyHook: params.notifyHook,
       title: params.title,
       tags: params.tags,
+      instrumental: params.instrumental,
       mv: params.mv,
       continueClipId: params.continueClipId,
       continueTaskId: params.continueTaskId,
@@ -200,6 +203,10 @@ export const audioGenerationTool: MCPTool = {
       tags: {
         type: 'string',
         description: '风格标签，逗号分隔',
+      },
+      instrumental: {
+        type: 'boolean',
+        description: '是否只生成纯音乐，不生成演唱人声',
       },
       mv: {
         type: 'string',

--- a/packages/drawnix/src/services/__tests__/audio-api-service.test.ts
+++ b/packages/drawnix/src/services/__tests__/audio-api-service.test.ts
@@ -52,6 +52,7 @@ describe('audio-api-service', () => {
     });
 
     vi.doMock('../../utils/settings-manager', () => ({
+      providerPricingCacheSettings: { get: () => null, update: vi.fn() },
       resolveInvocationRoute: () => ({
         profileId: 'runtime',
         profileName: 'Runtime',
@@ -62,15 +63,20 @@ describe('audio-api-service', () => {
       }),
     }));
 
-    const { audioAPIService, extractAudioGenerationResult } = await import('../audio-api-service');
+    const { audioAPIService, extractAudioGenerationResult } = await import(
+      '../audio-api-service'
+    );
 
-    const result = await audioAPIService.generateAudioWithPolling({
-      model: 'suno_music',
-      prompt: 'write a heavy metal song',
-    }, {
-      interval: 1,
-      maxAttempts: 2,
-    });
+    const result = await audioAPIService.generateAudioWithPolling(
+      {
+        model: 'suno_music',
+        prompt: 'write a heavy metal song',
+      },
+      {
+        interval: 1,
+        maxAttempts: 2,
+      }
+    );
 
     expect(sendMock).toHaveBeenCalledTimes(2);
     expect(sendMock.mock.calls[0]?.[1]).toMatchObject({
@@ -112,6 +118,7 @@ describe('audio-api-service', () => {
     });
 
     vi.doMock('../../utils/settings-manager', () => ({
+      providerPricingCacheSettings: { get: () => null, update: vi.fn() },
       resolveInvocationRoute: () => ({
         profileId: 'runtime',
         profileName: 'Runtime',
@@ -187,6 +194,7 @@ describe('audio-api-service', () => {
     });
 
     vi.doMock('../../utils/settings-manager', () => ({
+      providerPricingCacheSettings: { get: () => null, update: vi.fn() },
       resolveInvocationRoute: () => ({
         profileId: 'runtime',
         profileName: 'Runtime',
@@ -197,7 +205,9 @@ describe('audio-api-service', () => {
       }),
     }));
 
-    const { audioAPIService, extractAudioGenerationResult } = await import('../audio-api-service');
+    const { audioAPIService, extractAudioGenerationResult } = await import(
+      '../audio-api-service'
+    );
 
     const result = await audioAPIService.resumePolling(taskId, {
       interval: 1,
@@ -261,6 +271,7 @@ describe('audio-api-service', () => {
     });
 
     vi.doMock('../../utils/settings-manager', () => ({
+      providerPricingCacheSettings: { get: () => null, update: vi.fn() },
       resolveInvocationRoute: () => ({
         profileId: 'runtime',
         profileName: 'Runtime',
@@ -277,6 +288,7 @@ describe('audio-api-service', () => {
       {
         model: 'suno_music',
         prompt: '继续完善副歌',
+        instrumental: true,
         continueClipId: 'clip-continue-1',
         continueTaskId: 'task-continue-1',
         continueAt: 32,
@@ -294,8 +306,11 @@ describe('audio-api-service', () => {
       path: '/suno/submit/music',
       method: 'POST',
     });
-    expect(JSON.parse(sendMock.mock.calls[0]?.[1]?.body as string)).toMatchObject({
+    expect(
+      JSON.parse(sendMock.mock.calls[0]?.[1]?.body as string)
+    ).toMatchObject({
       prompt: '继续完善副歌',
+      make_instrumental: true,
       continue_clip_id: 'clip-continue-1',
       task_id: 'task-continue-1',
       continue_at: 32,
@@ -389,6 +404,7 @@ describe('audio-api-service', () => {
     });
 
     vi.doMock('../../utils/settings-manager', () => ({
+      providerPricingCacheSettings: { get: () => null, update: vi.fn() },
       resolveInvocationRoute: () => ({
         profileId: 'runtime',
         profileName: 'Runtime',
@@ -399,7 +415,9 @@ describe('audio-api-service', () => {
       }),
     }));
 
-    const { audioAPIService, extractAudioGenerationResult } = await import('../audio-api-service');
+    const { audioAPIService, extractAudioGenerationResult } = await import(
+      '../audio-api-service'
+    );
 
     const result = await audioAPIService.generateAudioWithPolling(
       {
@@ -469,6 +487,7 @@ describe('audio-api-service', () => {
     });
 
     vi.doMock('../../utils/settings-manager', () => ({
+      providerPricingCacheSettings: { get: () => null, update: vi.fn() },
       resolveInvocationRoute: () => ({
         profileId: 'runtime',
         profileName: 'Runtime',
@@ -479,7 +498,9 @@ describe('audio-api-service', () => {
       }),
     }));
 
-    const { audioAPIService, extractAudioGenerationResult } = await import('../audio-api-service');
+    const { audioAPIService, extractAudioGenerationResult } = await import(
+      '../audio-api-service'
+    );
 
     const result = await audioAPIService.generateAudioWithPolling(
       {
@@ -570,6 +591,7 @@ describe('audio-api-service', () => {
     });
 
     vi.doMock('../../utils/settings-manager', () => ({
+      providerPricingCacheSettings: { get: () => null, update: vi.fn() },
       resolveInvocationRoute: () => ({
         profileId: 'runtime',
         profileName: 'Runtime',
@@ -580,7 +602,9 @@ describe('audio-api-service', () => {
       }),
     }));
 
-    const { audioAPIService, extractAudioGenerationResult } = await import('../audio-api-service');
+    const { audioAPIService, extractAudioGenerationResult } = await import(
+      '../audio-api-service'
+    );
 
     const result = await audioAPIService.generateAudioWithPolling(
       {
@@ -654,6 +678,7 @@ describe('audio-api-service', () => {
     });
 
     vi.doMock('../../utils/settings-manager', () => ({
+      providerPricingCacheSettings: { get: () => null, update: vi.fn() },
       resolveInvocationRoute: () => ({
         profileId: 'runtime',
         profileName: 'Runtime',
@@ -664,7 +689,9 @@ describe('audio-api-service', () => {
       }),
     }));
 
-    const { audioAPIService, extractAudioGenerationResult } = await import('../audio-api-service');
+    const { audioAPIService, extractAudioGenerationResult } = await import(
+      '../audio-api-service'
+    );
 
     const result = await audioAPIService.generateAudioWithPolling(
       {

--- a/packages/drawnix/src/services/__tests__/canvas-audio-playback-service.test.ts
+++ b/packages/drawnix/src/services/__tests__/canvas-audio-playback-service.test.ts
@@ -4,6 +4,7 @@ vi.mock('../media-executor/fallback-utils', () => ({
   cacheRemoteUrl: vi.fn(async (url: string) => url),
 }));
 
+import { cacheRemoteUrl } from '../media-executor/fallback-utils';
 import {
   CanvasAudioPlaybackService,
   DEFAULT_PLAYBACK_MODE,
@@ -13,6 +14,9 @@ import {
 import { ttsSettings } from '../../utils/settings-manager';
 
 beforeEach(async () => {
+  vi.mocked(cacheRemoteUrl)
+    .mockReset()
+    .mockImplementation(async (url) => url);
   globalThis.localStorage?.clear?.();
   await ttsSettings.update({
     selectedVoice: '',
@@ -26,15 +30,16 @@ import { createReadingPlaybackSource } from '../reading-playback-source';
 
 class MockAudioElement extends EventTarget {
   src = '';
+  crossOrigin = '';
   currentTime = 0;
   duration = 0;
   preload = '';
   volume = 1;
   playbackRate = 1;
 
-  async play(): Promise<void> {
+  play = vi.fn(async (): Promise<void> => {
     this.dispatchEvent(new Event('play'));
-  }
+  });
 
   pause(): void {
     this.dispatchEvent(new Event('pause'));
@@ -48,11 +53,15 @@ class MockAudioElement extends EventTarget {
     if (name === 'src') {
       this.src = '';
     }
+    if (name.toLowerCase() === 'crossorigin') {
+      this.crossOrigin = '';
+    }
   }
 }
 
 class MockMediaElementSourceNode {
   connect = vi.fn();
+  disconnect = vi.fn();
 }
 
 class MockAnalyserNode {
@@ -78,7 +87,9 @@ class MockAudioContext {
   readonly mediaSource = new MockMediaElementSourceNode();
   readonly analyser = new MockAnalyserNode();
 
-  createMediaElementSource = vi.fn(() => this.mediaSource as unknown as MediaElementAudioSourceNode);
+  createMediaElementSource = vi.fn(
+    () => this.mediaSource as unknown as MediaElementAudioSourceNode
+  );
   createAnalyser = vi.fn(() => this.analyser as unknown as AnalyserNode);
   resume = vi.fn(async () => {
     this.state = 'running';
@@ -127,7 +138,9 @@ describe('CanvasAudioPlaybackService', () => {
   it('starts playback and stores active metadata for a source', async () => {
     const audio = new MockAudioElement();
     audio.duration = 215;
-    const service = new CanvasAudioPlaybackService(() => audio as unknown as HTMLAudioElement);
+    const service = new CanvasAudioPlaybackService(
+      () => audio as unknown as HTMLAudioElement
+    );
 
     await service.togglePlayback({
       elementId: 'audio-node-1',
@@ -145,11 +158,133 @@ describe('CanvasAudioPlaybackService', () => {
       duration: 215,
       playing: true,
     });
+    expect(audio.crossOrigin).toBe('');
+  });
+
+  it('falls back to the original remote URL when cached playback is rejected', async () => {
+    const cachedUrl = '/__aitu_generated__/audio/cached-track.mp3';
+    const remoteUrl = 'https://example.com/remote-track.mp3';
+    vi.mocked(cacheRemoteUrl).mockResolvedValue(cachedUrl);
+
+    const audio = new MockAudioElement();
+    audio.play
+      .mockRejectedValueOnce(new Error('cached media unavailable'))
+      .mockImplementationOnce(async () => {
+        audio.dispatchEvent(new Event('play'));
+      });
+    const service = new CanvasAudioPlaybackService(
+      () => audio as unknown as HTMLAudioElement
+    );
+
+    await service.togglePlayback({
+      elementId: 'audio-node-fallback',
+      audioUrl: remoteUrl,
+      title: 'Fallback Track',
+    });
+
+    expect(audio.play).toHaveBeenCalledTimes(2);
+    expect(audio.src).toBe(remoteUrl);
+    expect(audio.crossOrigin).toBe('');
+    expect(service.getState()).toMatchObject({
+      playing: true,
+      activeAudioUrl: remoteUrl,
+      error: undefined,
+    });
+  });
+
+  it('replaces an analysed audio element before falling back to a remote URL', async () => {
+    const cachedUrl = '/__aitu_generated__/audio/cached-track.mp3';
+    const remoteUrl = 'https://example.com/remote-track.mp3';
+    vi.mocked(cacheRemoteUrl).mockResolvedValue(cachedUrl);
+
+    const cachedAudio = new MockAudioElement();
+    const remoteAudio = new MockAudioElement();
+    const audioContext = new MockAudioContext();
+    const audioFactory = vi
+      .fn<() => HTMLAudioElement>()
+      .mockReturnValueOnce(cachedAudio as unknown as HTMLAudioElement)
+      .mockReturnValueOnce(remoteAudio as unknown as HTMLAudioElement);
+    const service = new CanvasAudioPlaybackService(audioFactory, {
+      audioContextFactory: () => audioContext as unknown as AudioContext,
+    });
+
+    await service.togglePlayback({
+      elementId: 'audio-node-analysed',
+      audioUrl: remoteUrl,
+    });
+    await Promise.resolve();
+    expect(audioContext.createMediaElementSource).toHaveBeenCalledWith(
+      cachedAudio
+    );
+
+    cachedAudio.dispatchEvent(new Event('error'));
+    await vi.waitFor(() => expect(remoteAudio.play).toHaveBeenCalledOnce());
+
+    expect(audioFactory).toHaveBeenCalledTimes(2);
+    expect(audioContext.mediaSource.disconnect).toHaveBeenCalledOnce();
+    expect(remoteAudio.src).toBe(remoteUrl);
+    expect(service.getState()).toMatchObject({
+      playing: true,
+      analysisAvailable: false,
+      error: undefined,
+    });
+  });
+
+  it('plays a direct remote URL without creating a Web Audio analysis graph', async () => {
+    const audio = new MockAudioElement();
+    const audioContext = new MockAudioContext();
+    const service = new CanvasAudioPlaybackService(
+      () => audio as unknown as HTMLAudioElement,
+      {
+        audioContextFactory: () => audioContext as unknown as AudioContext,
+      }
+    );
+
+    await service.togglePlayback({
+      elementId: 'audio-node-direct',
+      audioUrl: 'https://example.com/direct-track.mp3',
+    });
+    await Promise.resolve();
+
+    expect(audio.play).toHaveBeenCalledOnce();
+    expect(audioContext.createMediaElementSource).not.toHaveBeenCalled();
+    expect(service.getState()).toMatchObject({
+      playing: true,
+      analysisAvailable: false,
+    });
+  });
+
+  it('reports a final remote playback failure without retrying again', async () => {
+    vi.mocked(cacheRemoteUrl).mockResolvedValue(
+      '/__aitu_generated__/audio/cached-track.mp3'
+    );
+    const audio = new MockAudioElement();
+    audio.play
+      .mockRejectedValueOnce(new Error('cached media unavailable'))
+      .mockRejectedValueOnce(new Error('remote media unavailable'));
+    const service = new CanvasAudioPlaybackService(
+      () => audio as unknown as HTMLAudioElement
+    );
+
+    await expect(
+      service.togglePlayback({
+        elementId: 'audio-node-final-error',
+        audioUrl: 'https://example.com/remote-track.mp3',
+      })
+    ).rejects.toThrow('cached media unavailable');
+
+    expect(audio.play).toHaveBeenCalledTimes(2);
+    expect(service.getState()).toMatchObject({
+      playing: false,
+      error: 'remote media unavailable',
+    });
   });
 
   it('pauses when toggling the same source twice', async () => {
     const audio = new MockAudioElement();
-    const service = new CanvasAudioPlaybackService(() => audio as unknown as HTMLAudioElement);
+    const service = new CanvasAudioPlaybackService(
+      () => audio as unknown as HTMLAudioElement
+    );
     const source = {
       elementId: 'audio-node-2',
       audioUrl: 'https://example.com/audio-2.mp3',
@@ -167,7 +302,9 @@ describe('CanvasAudioPlaybackService', () => {
   it('seeks and clears playback state', async () => {
     const audio = new MockAudioElement();
     audio.duration = 120;
-    const service = new CanvasAudioPlaybackService(() => audio as unknown as HTMLAudioElement);
+    const service = new CanvasAudioPlaybackService(
+      () => audio as unknown as HTMLAudioElement
+    );
 
     await service.togglePlayback({
       elementId: 'audio-node-3',
@@ -190,7 +327,9 @@ describe('CanvasAudioPlaybackService', () => {
 
   it('keeps a canvas queue and can move between tracks', async () => {
     const audio = new MockAudioElement();
-    const service = new CanvasAudioPlaybackService(() => audio as unknown as HTMLAudioElement);
+    const service = new CanvasAudioPlaybackService(
+      () => audio as unknown as HTMLAudioElement
+    );
 
     service.setQueue([
       {
@@ -235,7 +374,9 @@ describe('CanvasAudioPlaybackService', () => {
 
   it('tracks playlist queue metadata separately from canvas queue', async () => {
     const audio = new MockAudioElement();
-    const service = new CanvasAudioPlaybackService(() => audio as unknown as HTMLAudioElement);
+    const service = new CanvasAudioPlaybackService(
+      () => audio as unknown as HTMLAudioElement
+    );
 
     service.setQueue(
       [
@@ -268,7 +409,9 @@ describe('CanvasAudioPlaybackService', () => {
 
   it('switches to the provided canvas queue before playback starts', async () => {
     const audio = new MockAudioElement();
-    const service = new CanvasAudioPlaybackService(() => audio as unknown as HTMLAudioElement);
+    const service = new CanvasAudioPlaybackService(
+      () => audio as unknown as HTMLAudioElement
+    );
 
     service.setQueue(
       [
@@ -321,7 +464,9 @@ describe('CanvasAudioPlaybackService', () => {
 
   it('updates stored canvas queue without overriding playlist playback context', () => {
     const audio = new MockAudioElement();
-    const service = new CanvasAudioPlaybackService(() => audio as unknown as HTMLAudioElement);
+    const service = new CanvasAudioPlaybackService(
+      () => audio as unknown as HTMLAudioElement
+    );
 
     service.setQueue(
       [
@@ -362,7 +507,9 @@ describe('CanvasAudioPlaybackService', () => {
 
   it('updates audio volume and keeps it after clearing playback', async () => {
     const audio = new MockAudioElement();
-    const service = new CanvasAudioPlaybackService(() => audio as unknown as HTMLAudioElement);
+    const service = new CanvasAudioPlaybackService(
+      () => audio as unknown as HTMLAudioElement
+    );
 
     service.setVolume(0.35);
     expect(service.getState().volume).toBe(0.35);
@@ -381,7 +528,9 @@ describe('CanvasAudioPlaybackService', () => {
 
   it('updates audio playback rate and persists it across service instances', async () => {
     const audio = new MockAudioElement();
-    const service = new CanvasAudioPlaybackService(() => audio as unknown as HTMLAudioElement);
+    const service = new CanvasAudioPlaybackService(
+      () => audio as unknown as HTMLAudioElement
+    );
 
     service.setPlaybackRate(1.5, 'audio');
     expect(service.getState()).toMatchObject({
@@ -404,7 +553,9 @@ describe('CanvasAudioPlaybackService', () => {
   it('stops at queue end in sequential mode when playback ends', async () => {
     const audio = new MockAudioElement();
     audio.duration = 180;
-    const service = new CanvasAudioPlaybackService(() => audio as unknown as HTMLAudioElement);
+    const service = new CanvasAudioPlaybackService(
+      () => audio as unknown as HTMLAudioElement
+    );
     const queue = [
       {
         elementId: 'audio-node-1',
@@ -434,7 +585,9 @@ describe('CanvasAudioPlaybackService', () => {
 
   it('loops back to the first track in list-loop mode when playback ends', async () => {
     const audio = new MockAudioElement();
-    const service = new CanvasAudioPlaybackService(() => audio as unknown as HTMLAudioElement);
+    const service = new CanvasAudioPlaybackService(
+      () => audio as unknown as HTMLAudioElement
+    );
     const queue = [
       {
         elementId: 'audio-node-1',
@@ -465,7 +618,9 @@ describe('CanvasAudioPlaybackService', () => {
 
   it('restarts the same track in single-loop mode when playback ends', async () => {
     const audio = new MockAudioElement();
-    const service = new CanvasAudioPlaybackService(() => audio as unknown as HTMLAudioElement);
+    const service = new CanvasAudioPlaybackService(
+      () => audio as unknown as HTMLAudioElement
+    );
     const track = {
       elementId: 'audio-node-1',
       audioUrl: 'https://example.com/audio-1.mp3',
@@ -492,7 +647,9 @@ describe('CanvasAudioPlaybackService', () => {
 
   it('uses a different queue item for shuffle auto-advance when possible', async () => {
     const audio = new MockAudioElement();
-    const service = new CanvasAudioPlaybackService(() => audio as unknown as HTMLAudioElement);
+    const service = new CanvasAudioPlaybackService(
+      () => audio as unknown as HTMLAudioElement
+    );
     const queue = [
       {
         elementId: 'audio-node-1',
@@ -544,21 +701,21 @@ describe('CanvasAudioPlaybackService', () => {
 
     await service.togglePlayback({
       elementId: 'audio-node-reactive',
-      audioUrl: 'https://example.com/audio-reactive.mp3',
+      audioUrl: '/__aitu_generated__/audio/audio-reactive.mp3',
       title: 'Reactive Track',
     });
 
     await Promise.resolve();
 
     audioContext.analyser.data.set([
-      220, 200, 180, 120, 90, 70, 60, 55,
-      48, 42, 38, 33, 28, 24, 20, 18,
-      16, 14, 12, 10, 9, 8, 7, 6,
-      5, 4, 4, 3, 3, 2, 2, 1,
+      220, 200, 180, 120, 90, 70, 60, 55, 48, 42, 38, 33, 28, 24, 20, 18, 16,
+      14, 12, 10, 9, 8, 7, 6, 5, 4, 4, 3, 3, 2, 2, 1,
     ]);
     audioContext.analyser.timeDomainData.set(
-      Uint8Array.from({ length: 256 }, (_, index) =>
-        128 + Math.round(Math.sin((index / 256) * Math.PI * 12) * 54)
+      Uint8Array.from(
+        { length: 256 },
+        (_, index) =>
+          128 + Math.round(Math.sin((index / 256) * Math.PI * 12) * 54)
       )
     );
 
@@ -567,7 +724,9 @@ describe('CanvasAudioPlaybackService', () => {
     const state = service.getState();
     expect(state.analysisAvailable).toBe(true);
     expect(state.spectrumLevels.some((level) => level > 0.05)).toBe(true);
-    expect(state.waveformLevels.some((level) => Math.abs(level) > 0.04)).toBe(true);
+    expect(state.waveformLevels.some((level) => Math.abs(level) > 0.04)).toBe(
+      true
+    );
     expect(state.pulseLevel).toBeGreaterThan(0.05);
   });
 
@@ -590,7 +749,7 @@ describe('CanvasAudioPlaybackService', () => {
 
     await service.togglePlayback({
       elementId: 'audio-node-reactive-stop',
-      audioUrl: 'https://example.com/audio-reactive-stop.mp3',
+      audioUrl: '/__aitu_generated__/audio/audio-reactive-stop.mp3',
       title: 'Reactive Stop',
     });
 
@@ -603,8 +762,12 @@ describe('CanvasAudioPlaybackService', () => {
 
     expect(service.getState().analysisAvailable).toBe(false);
     expect(service.getState().pulseLevel).toBe(0);
-    expect(service.getState().spectrumLevels).toEqual([...EMPTY_AUDIO_SPECTRUM]);
-    expect(service.getState().waveformLevels).toEqual([...EMPTY_AUDIO_WAVEFORM]);
+    expect(service.getState().spectrumLevels).toEqual([
+      ...EMPTY_AUDIO_SPECTRUM,
+    ]);
+    expect(service.getState().waveformLevels).toEqual([
+      ...EMPTY_AUDIO_WAVEFORM,
+    ]);
   });
 
   it('plays reading sources and tracks subtitle progress', () => {
@@ -638,7 +801,10 @@ describe('CanvasAudioPlaybackService', () => {
       }
     );
 
-    service.toggleReadingPlaybackInQueue(readingSource ? [readingSource][0] : (null as never), readingSource ? [readingSource] : []);
+    service.toggleReadingPlaybackInQueue(
+      readingSource ? [readingSource][0] : (null as never),
+      readingSource ? [readingSource] : []
+    );
 
     expect(service.getState()).toMatchObject({
       mediaType: 'reading',
@@ -683,7 +849,10 @@ describe('CanvasAudioPlaybackService', () => {
     );
 
     service.setPlaybackMode('single-loop');
-    service.toggleReadingPlaybackInQueue(readingSource ? [readingSource][0] : (null as never), readingSource ? [readingSource] : []);
+    service.toggleReadingPlaybackInQueue(
+      readingSource ? [readingSource][0] : (null as never),
+      readingSource ? [readingSource] : []
+    );
 
     const firstUtterance = speechSynthesis.utterances[0];
     firstUtterance?.onend?.(new Event('end') as SpeechSynthesisEvent);
@@ -721,7 +890,10 @@ describe('CanvasAudioPlaybackService', () => {
       }
     );
 
-    service.toggleReadingPlaybackInQueue(readingSource ? [readingSource][0] : (null as never), readingSource ? [readingSource] : []);
+    service.toggleReadingPlaybackInQueue(
+      readingSource ? [readingSource][0] : (null as never),
+      readingSource ? [readingSource] : []
+    );
     service.setPlaybackRate(1.5, 'reading');
     await Promise.resolve();
 
@@ -755,7 +927,10 @@ describe('CanvasAudioPlaybackService', () => {
       }
     );
 
-    service.toggleReadingPlaybackInQueue(readingSource ? [readingSource][0] : (null as never), readingSource ? [readingSource] : []);
+    service.toggleReadingPlaybackInQueue(
+      readingSource ? [readingSource][0] : (null as never),
+      readingSource ? [readingSource] : []
+    );
     await ttsSettings.update({ rate: 2 });
 
     expect(service.getState()).toMatchObject({

--- a/packages/drawnix/src/services/audio-api-service.ts
+++ b/packages/drawnix/src/services/audio-api-service.ts
@@ -42,6 +42,7 @@ export interface AudioGenerationParams {
   prompt: string;
   title?: string;
   tags?: string;
+  instrumental?: boolean;
   mv?: string;
   sunoAction?: string;
   notifyHook?: string;
@@ -136,9 +137,9 @@ function resolveAudioProviderContext(
 
 function resolveAudioPlanContext(routeModel?: string | ModelRef | null): {
   providerContext: ResolvedProviderContext;
-  binding: NonNullable<
-    ReturnType<typeof resolveInvocationPlanFromRoute>
-  >['binding'] | null;
+  binding:
+    | NonNullable<ReturnType<typeof resolveInvocationPlanFromRoute>>['binding']
+    | null;
 } {
   const plan = resolveInvocationPlanFromRoute('audio', routeModel);
   return {
@@ -149,9 +150,9 @@ function resolveAudioPlanContext(routeModel?: string | ModelRef | null): {
 
 function inferAudioBaseUrlStrategy(
   providerContext: ResolvedProviderContext,
-  binding?: NonNullable<
-    ReturnType<typeof resolveInvocationPlanFromRoute>
-  >['binding'] | null
+  binding?:
+    | NonNullable<ReturnType<typeof resolveInvocationPlanFromRoute>>['binding']
+    | null
 ): ProviderBaseUrlStrategy | undefined {
   if (binding?.baseUrlStrategy) {
     return binding.baseUrlStrategy;
@@ -169,9 +170,7 @@ function inferAudioBaseUrlStrategy(
 }
 
 function replaceTaskIdTemplate(pathTemplate: string, taskId: string): string {
-  return pathTemplate
-    .replace('{taskId}', taskId)
-    .replace('{task_id}', taskId);
+  return pathTemplate.replace('{taskId}', taskId).replace('{task_id}', taskId);
 }
 
 function normalizeStatus(value: unknown): string {
@@ -194,7 +193,9 @@ function normalizeSunoAction(value: unknown): SunoAction | undefined {
   return undefined;
 }
 
-function resolveSunoModelId(model?: string | ModelRef | null): string | undefined {
+function resolveSunoModelId(
+  model?: string | ModelRef | null
+): string | undefined {
   if (!model) {
     return undefined;
   }
@@ -341,7 +342,11 @@ function extractLyricsPayload(payload: any): AudioLyricsPayload | null {
   let fallback: AudioLyricsPayload | null = null;
 
   for (const candidate of candidates) {
-    if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+    if (
+      !candidate ||
+      typeof candidate !== 'object' ||
+      Array.isArray(candidate)
+    ) {
       continue;
     }
 
@@ -462,7 +467,9 @@ function extractAudioClips(payload: any): AudioClipRecord[] {
 }
 
 function resolveClipIdentifier(clip: AudioClipRecord): string | undefined {
-  return normalizeOptionalString(clip.clip_id) || normalizeOptionalString(clip.id);
+  return (
+    normalizeOptionalString(clip.clip_id) || normalizeOptionalString(clip.id)
+  );
 }
 
 function createClipIdentifierMemory(): ClipIdentifierMemory {
@@ -506,7 +513,10 @@ function applyRememberedClipIdentifiers(
     }
 
     let rememberedClipId: string | undefined;
-    if (typeof clip.batch_index === 'number' && Number.isFinite(clip.batch_index)) {
+    if (
+      typeof clip.batch_index === 'number' &&
+      Number.isFinite(clip.batch_index)
+    ) {
       rememberedClipId = memory.byBatchIndex.get(clip.batch_index);
     }
     if (!rememberedClipId) {
@@ -543,7 +553,9 @@ function normalizeAudioClipResult(
     imageLargeUrl: normalizeOptionalString(clip.image_large_url),
     duration:
       clip.duration ??
-      (typeof clip.metadata?.duration === 'number' ? clip.metadata.duration : null),
+      (typeof clip.metadata?.duration === 'number'
+        ? clip.metadata.duration
+        : null),
     modelName: normalizeOptionalString(clip.model_name),
     majorModelVersion: normalizeOptionalString(clip.major_model_version),
   };
@@ -569,7 +581,8 @@ function extractFailureReason(payload: any, clips: AudioClipRecord[]): string {
     }
   }
 
-  return normalizeSunoAction(payload?.action || payload?.data?.action) === 'lyrics'
+  return normalizeSunoAction(payload?.action || payload?.data?.action) ===
+    'lyrics'
     ? '歌词生成失败'
     : '音乐生成失败';
 }
@@ -604,9 +617,13 @@ function normalizeAudioTaskResponse(
 ): AudioTaskResponse {
   const extractedClips = extractAudioClips(payload).sort((left, right) => {
     const leftIndex =
-      typeof left.batch_index === 'number' ? left.batch_index : Number.MAX_SAFE_INTEGER;
+      typeof left.batch_index === 'number'
+        ? left.batch_index
+        : Number.MAX_SAFE_INTEGER;
     const rightIndex =
-      typeof right.batch_index === 'number' ? right.batch_index : Number.MAX_SAFE_INTEGER;
+      typeof right.batch_index === 'number'
+        ? right.batch_index
+        : Number.MAX_SAFE_INTEGER;
     return leftIndex - rightIndex;
   });
   if (clipMemory) {
@@ -625,11 +642,12 @@ function normalizeAudioTaskResponse(
       normalizeStatus(payload?.data?.data?.action) ||
       undefined,
     status: normalizeLifecycleStatus(payload),
-    progress: resolveProgressValue(
-      payload?.progress,
-      payload?.data?.progress,
-      payload?.data?.data?.progress
-    ) ??
+    progress:
+      resolveProgressValue(
+        payload?.progress,
+        payload?.data?.progress,
+        payload?.data?.data?.progress
+      ) ??
       (clips.length > 0 &&
       clips.every((clip) =>
         isTerminalSuccess(normalizeStatus(clip.status || clip.state))
@@ -679,9 +697,20 @@ function buildMusicSubmitBody(params: AudioGenerationParams): string {
     mv: resolveVersionValue(params),
   };
 
+  const instrumental =
+    params.instrumental ??
+    (typeof params.params?.instrumental === 'boolean'
+      ? params.params.instrumental
+      : params.params?.instrumental === 'true');
+  if (instrumental) {
+    body.make_instrumental = true;
+  }
+
   const title =
     params.title ||
-    (typeof params.params?.title === 'string' ? params.params.title : undefined);
+    (typeof params.params?.title === 'string'
+      ? params.params.title
+      : undefined);
   const tags =
     params.tags ||
     (typeof params.params?.tags === 'string' ? params.params.tags : undefined);
@@ -736,10 +765,7 @@ function buildMusicSubmitBody(params: AudioGenerationParams): string {
   ) {
     body.infill_start_s = infillStartSValue;
   }
-  if (
-    typeof infillEndSValue === 'number' &&
-    Number.isFinite(infillEndSValue)
-  ) {
+  if (typeof infillEndSValue === 'number' && Number.isFinite(infillEndSValue)) {
     body.infill_end_s = infillEndSValue;
   }
 
@@ -775,9 +801,9 @@ function buildSubmitBody(params: AudioGenerationParams): string {
 
 function resolveSubmitPath(
   params: AudioGenerationParams,
-  binding?: NonNullable<
-    ReturnType<typeof resolveInvocationPlanFromRoute>
-  >['binding'] | null
+  binding?:
+    | NonNullable<ReturnType<typeof resolveInvocationPlanFromRoute>>['binding']
+    | null
 ): string {
   const action = resolveRequestedAction(params);
   const submitPathByAction = binding?.metadata?.audio?.submitPathByAction;
@@ -826,10 +852,15 @@ export function extractAudioGenerationResult(
 
   const urls = clipsWithAudio
     .map((clip) => clip.audioUrl)
-    .filter((url): url is string => typeof url === 'string' && url.trim().length > 0);
+    .filter(
+      (url): url is string => typeof url === 'string' && url.trim().length > 0
+    );
   const clipIds = clipsWithAudio
     .map((clip) => clip.clipId || clip.id)
-    .filter((clipId): clipId is string => typeof clipId === 'string' && clipId.length > 0);
+    .filter(
+      (clipId): clipId is string =>
+        typeof clipId === 'string' && clipId.length > 0
+    );
 
   return {
     url: primaryUrl,
@@ -855,23 +886,27 @@ function hasResolvedTaskResult(response: AudioTaskResponse): boolean {
     );
   }
 
-  return typeof response.lyrics?.text === 'string' &&
-    response.lyrics.text.trim().length > 0;
+  return (
+    typeof response.lyrics?.text === 'string' &&
+    response.lyrics.text.trim().length > 0
+  );
 }
 
 function normalizeManualAudioTaskResponse(
   payload: unknown,
   fallbackTaskId = '',
-  binding?: NonNullable<
-    ReturnType<typeof resolveInvocationPlanFromRoute>
-  >['binding'] | null,
+  binding?:
+    | NonNullable<ReturnType<typeof resolveInvocationPlanFromRoute>>['binding']
+    | null,
   usePollPaths = false
 ): AudioTaskResponse {
   const template = getManualHttpTemplate(binding?.metadata);
   const task = normalizeManualTaskResponse(
     payload,
     usePollPaths
-      ? template?.pollResponsePaths || template?.pollPaths || template?.responsePaths
+      ? template?.pollResponsePaths ||
+          template?.pollPaths ||
+          template?.responsePaths
       : template?.responsePaths
   );
   const audioUrls = [task.audioUrl, ...(task.audioUrls || [])].filter(
@@ -924,6 +959,8 @@ class AudioAPIService {
         ...params.params,
         title: params.title,
         tags: params.tags,
+        instrumental: params.instrumental,
+        make_instrumental: params.instrumental,
         mv: params.mv,
         sunoAction: params.sunoAction,
         notifyHook: params.notifyHook,
@@ -988,7 +1025,9 @@ class AudioAPIService {
         errorMessage: errorText.substring(0, 500),
       });
       const error = new Error(
-        `${action === 'lyrics' ? '歌词' : '音乐'}生成提交失败: ${response.status} - ${errorText}`
+        `${action === 'lyrics' ? '歌词' : '音乐'}生成提交失败: ${
+          response.status
+        } - ${errorText}`
       );
       (error as any).apiErrorBody = errorText;
       (error as any).httpStatus = response.status;
@@ -1036,13 +1075,16 @@ class AudioAPIService {
       ? replaceTaskIdTemplate(binding.pollPathTemplate, taskId)
       : `/suno/fetch/${taskId}`;
     const variables = buildManualHttpVariables({
-      model: typeof routeModel === 'string' ? routeModel : routeModel?.modelId || '',
+      model:
+        typeof routeModel === 'string' ? routeModel : routeModel?.modelId || '',
       taskId,
       params: {},
     });
 
     const response = await providerTransport.send(providerContext, {
-      path: manualHttpTemplate ? (renderTemplate(path, variables) as string) : path,
+      path: manualHttpTemplate
+        ? (renderTemplate(path, variables) as string)
+        : path,
       baseUrlStrategy,
       method: 'GET',
       headers: manualHttpTemplate
@@ -1084,7 +1126,9 @@ class AudioAPIService {
 
     if (!submitResponse.taskId.trim()) {
       throw new Error(
-        `${resolveRequestedAction(params) === 'lyrics' ? '歌词' : '音乐'}生成提交成功，但未返回任务 ID`
+        `${
+          resolveRequestedAction(params) === 'lyrics' ? '歌词' : '音乐'
+        }生成提交成功，但未返回任务 ID`
       );
     }
 
@@ -1105,7 +1149,10 @@ class AudioAPIService {
       );
     }
 
-    if (isTerminalSuccess(submitResponse.status) && hasResolvedTaskResult(submitResponse)) {
+    if (
+      isTerminalSuccess(submitResponse.status) &&
+      hasResolvedTaskResult(submitResponse)
+    ) {
       return submitResponse;
     }
 
@@ -1162,7 +1209,11 @@ class AudioAPIService {
 
       try {
         const payload = await this.queryAudioTask(taskId, options.routeModel);
-        const result = normalizeAudioTaskResponse(payload.raw, taskId, clipMemory);
+        const result = normalizeAudioTaskResponse(
+          payload.raw,
+          taskId,
+          clipMemory
+        );
         consecutiveErrors = 0;
 
         if (onProgress) {

--- a/packages/drawnix/src/services/canvas-audio-playback-service.ts
+++ b/packages/drawnix/src/services/canvas-audio-playback-service.ts
@@ -1,7 +1,4 @@
-import {
-  DEFAULT_TTS_SETTINGS,
-  resolveVoice,
-} from '../hooks/useTextToSpeech';
+import { DEFAULT_TTS_SETTINGS, resolveVoice } from '../hooks/useTextToSpeech';
 import { getFileExtension } from '@aitu/utils';
 import { LS_KEYS } from '../constants/storage-keys';
 import { ttsSettings, type TtsSettings } from '../utils/settings-manager';
@@ -28,12 +25,20 @@ export type PlaybackQueueSource = 'canvas' | 'playlist' | 'reading';
 export type CanvasAudioQueueSource = PlaybackQueueSource;
 export type PlaybackMediaType = 'audio' | 'reading' | null;
 export type PlaybackRateMediaType = Exclude<PlaybackMediaType, null>;
-export type PlaybackQueueItem = CanvasAudioPlaybackSource | ReadingPlaybackSource;
-export type PlaybackMode = 'sequential' | 'list-loop' | 'single-loop' | 'shuffle';
+export type PlaybackQueueItem =
+  | CanvasAudioPlaybackSource
+  | ReadingPlaybackSource;
+export type PlaybackMode =
+  | 'sequential'
+  | 'list-loop'
+  | 'single-loop'
+  | 'shuffle';
 
 export const DEFAULT_PLAYBACK_MODE: PlaybackMode = 'sequential';
 export const AUDIO_PLAYBACK_SPEED_PRESETS = [0.75, 1, 1.25, 1.5, 2, 3] as const;
-export const READING_PLAYBACK_SPEED_PRESETS = [0.75, 1, 1.25, 1.5, 2, 3, 5, 10] as const;
+export const READING_PLAYBACK_SPEED_PRESETS = [
+  0.75, 1, 1.25, 1.5, 2, 3, 5, 10,
+] as const;
 export const DEFAULT_AUDIO_PLAYBACK_RATE = 1;
 export const PLAYBACK_MODE_LABELS: Record<PlaybackMode, string> = {
   sequential: '顺序播放',
@@ -58,12 +63,14 @@ export function getPlaybackSpeedPresets(
     : AUDIO_PLAYBACK_SPEED_PRESETS;
 }
 
-function isPlaybackMode(value: string | null | undefined): value is PlaybackMode {
+function isPlaybackMode(
+  value: string | null | undefined
+): value is PlaybackMode {
   return (
-    value === 'sequential'
-    || value === 'list-loop'
-    || value === 'single-loop'
-    || value === 'shuffle'
+    value === 'sequential' ||
+    value === 'list-loop' ||
+    value === 'single-loop' ||
+    value === 'shuffle'
   );
 }
 
@@ -73,7 +80,9 @@ function readPersistedPlaybackMode(): PlaybackMode {
   }
 
   try {
-    const stored = window.localStorage.getItem(LS_KEYS.AUDIO_PLAYER_PLAYBACK_MODE);
+    const stored = window.localStorage.getItem(
+      LS_KEYS.AUDIO_PLAYER_PLAYBACK_MODE
+    );
     return isPlaybackMode(stored) ? stored : DEFAULT_PLAYBACK_MODE;
   } catch {
     return DEFAULT_PLAYBACK_MODE;
@@ -114,7 +123,9 @@ function readPersistedAudioPlaybackRate(): number {
   }
 
   try {
-    const stored = window.localStorage.getItem(LS_KEYS.AUDIO_PLAYER_AUDIO_PLAYBACK_RATE);
+    const stored = window.localStorage.getItem(
+      LS_KEYS.AUDIO_PLAYER_AUDIO_PLAYBACK_RATE
+    );
     return normalizeAudioPlaybackRate(stored ? Number(stored) : undefined);
   } catch {
     return DEFAULT_AUDIO_PLAYBACK_RATE;
@@ -266,10 +277,17 @@ export class CanvasAudioPlaybackService {
   private canvasQueue: CanvasAudioPlaybackSource[] = [];
   private currentReadingSource: ReadingPlaybackSource | null = null;
   private readingVersion = 0;
-  private readingProgressHandle: number | ReturnType<typeof setInterval> | null = null;
+  private readingProgressHandle:
+    | number
+    | ReturnType<typeof setInterval>
+    | null = null;
   private readingSegmentResumeAt = 0;
   private readingSegmentOffsetMs = 0;
   private readingResumeRequiresRestart = false;
+  private directPlaybackFallbackUrl: string | null = null;
+  private playbackFallbackInProgress = false;
+  private playbackFallbackPromise: Promise<boolean> | null = null;
+  private analysisEnabledForCurrentAudio = true;
 
   constructor(
     private readonly audioFactory: () => HTMLAudioElement = () => new Audio(),
@@ -303,7 +321,9 @@ export class CanvasAudioPlaybackService {
   private patchState(
     partial:
       | Partial<CanvasAudioPlaybackState>
-      | ((current: CanvasAudioPlaybackState) => Partial<CanvasAudioPlaybackState>)
+      | ((
+          current: CanvasAudioPlaybackState
+        ) => Partial<CanvasAudioPlaybackState>)
   ): void {
     const patch = typeof partial === 'function' ? partial(this.state) : partial;
     this.setState({
@@ -334,7 +354,9 @@ export class CanvasAudioPlaybackService {
     this.patchState((current) => ({
       readingPlaybackRate: nextReadingRate,
       effectivePlaybackRate:
-        current.mediaType !== 'audio' ? nextReadingRate : current.effectivePlaybackRate,
+        current.mediaType !== 'audio'
+          ? nextReadingRate
+          : current.effectivePlaybackRate,
     }));
 
     if (this.state.mediaType !== 'reading' || !this.currentReadingSource) {
@@ -342,7 +364,10 @@ export class CanvasAudioPlaybackService {
     }
 
     if (this.state.playing) {
-      const nextSegmentIndex = Math.max(0, this.state.activeReadingSegmentIndex);
+      const nextSegmentIndex = Math.max(
+        0,
+        this.state.activeReadingSegmentIndex
+      );
       this.startReading(this.currentReadingSource, nextSegmentIndex);
       return;
     }
@@ -350,12 +375,17 @@ export class CanvasAudioPlaybackService {
     this.readingResumeRequiresRestart = true;
   };
 
-  private getUtteranceFactory(): ((text: string) => SpeechSynthesisUtterance) | null {
+  private getUtteranceFactory():
+    | ((text: string) => SpeechSynthesisUtterance)
+    | null {
     if (this.runtime.utteranceFactory) {
       return this.runtime.utteranceFactory;
     }
 
-    if (typeof window === 'undefined' || typeof window.SpeechSynthesisUtterance === 'undefined') {
+    if (
+      typeof window === 'undefined' ||
+      typeof window.SpeechSynthesisUtterance === 'undefined'
+    ) {
       return null;
     }
 
@@ -400,7 +430,6 @@ export class CanvasAudioPlaybackService {
       this.audio.preload = 'metadata';
       this.audio.volume = this.state.volume;
       this.audio.playbackRate = this.state.audioPlaybackRate;
-      this.audio.crossOrigin = 'anonymous';
       this.attachAudioListeners(this.audio);
     }
 
@@ -420,8 +449,10 @@ export class CanvasAudioPlaybackService {
       return undefined;
     }
 
-    const AudioContextCtor = window.AudioContext
-      || (window as Window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    const AudioContextCtor =
+      window.AudioContext ||
+      (window as Window & { webkitAudioContext?: typeof AudioContext })
+        .webkitAudioContext;
 
     if (!AudioContextCtor) {
       return undefined;
@@ -430,7 +461,9 @@ export class CanvasAudioPlaybackService {
     return () => new AudioContextCtor();
   }
 
-  private getRequestFrame(): ((callback: FrameRequestCallback) => number) | undefined {
+  private getRequestFrame():
+    | ((callback: FrameRequestCallback) => number)
+    | undefined {
     if (this.runtime.requestFrame) {
       return this.runtime.requestFrame;
     }
@@ -486,7 +519,10 @@ export class CanvasAudioPlaybackService {
     return normalized;
   }
 
-  private findQueueIndex(queue: PlaybackQueueItem[], source: PlaybackQueueItem): number {
+  private findQueueIndex(
+    queue: PlaybackQueueItem[],
+    source: PlaybackQueueItem
+  ): number {
     const sourceKey = this.getSourceKey(source);
     return queue.findIndex((item) => this.getSourceKey(item) === sourceKey);
   }
@@ -499,6 +535,16 @@ export class CanvasAudioPlaybackService {
     audio.addEventListener('loadedmetadata', this.handleLoadedMetadata);
     audio.addEventListener('durationchange', this.handleDurationChange);
     audio.addEventListener('error', this.handleError);
+  }
+
+  private detachAudioListeners(audio: HTMLAudioElement): void {
+    audio.removeEventListener('play', this.handlePlay);
+    audio.removeEventListener('pause', this.handlePause);
+    audio.removeEventListener('ended', this.handleEnded);
+    audio.removeEventListener('timeupdate', this.handleTimeUpdate);
+    audio.removeEventListener('loadedmetadata', this.handleLoadedMetadata);
+    audio.removeEventListener('durationchange', this.handleDurationChange);
+    audio.removeEventListener('error', this.handleError);
   }
 
   private handlePlay = (): void => {
@@ -533,9 +579,10 @@ export class CanvasAudioPlaybackService {
       return;
     }
 
-    const duration = this.audio && Number.isFinite(this.audio.duration)
-      ? this.audio.duration
-      : this.state.duration;
+    const duration =
+      this.audio && Number.isFinite(this.audio.duration)
+        ? this.audio.duration
+        : this.state.duration;
 
     this.stopAnalysisLoop();
     this.patchState({
@@ -587,6 +634,18 @@ export class CanvasAudioPlaybackService {
   };
 
   private handleError = (): void => {
+    if (this.playbackFallbackInProgress) {
+      return;
+    }
+
+    if (
+      this.audio &&
+      this.directPlaybackFallbackUrl &&
+      !this.playbackFallbackInProgress
+    ) {
+      void this.playDirectPlaybackFallback();
+      return;
+    }
     this.stopAnalysisLoop();
     this.patchState({
       playing: false,
@@ -598,7 +657,85 @@ export class CanvasAudioPlaybackService {
     });
   };
 
+  private replaceAudioElementForDirectPlayback(): void {
+    const previousAudio = this.audio;
+    if (!previousAudio) {
+      return;
+    }
+
+    this.detachAudioListeners(previousAudio);
+    this.stopAnalysisLoop();
+    this.mediaElementSource?.disconnect?.();
+    this.mediaElementSource = null;
+
+    const audio = this.audioFactory();
+    audio.preload = 'metadata';
+    audio.volume = this.state.volume;
+    audio.playbackRate = this.state.audioPlaybackRate;
+    this.audio = audio;
+    this.attachAudioListeners(audio);
+  }
+
+  private async performDirectPlaybackFallback(): Promise<boolean> {
+    const fallbackUrl = this.directPlaybackFallbackUrl;
+    if (!this.audio || !fallbackUrl || this.playbackFallbackInProgress) {
+      return false;
+    }
+
+    this.directPlaybackFallbackUrl = null;
+    this.playbackFallbackInProgress = true;
+    if (this.mediaElementSource) {
+      this.replaceAudioElementForDirectPlayback();
+    }
+
+    const audio = this.audio;
+    this.analysisEnabledForCurrentAudio = false;
+    this.stopAnalysisLoop();
+    audio.pause();
+    audio.removeAttribute('crossorigin');
+    audio.src = fallbackUrl;
+    audio.currentTime = 0;
+    try {
+      audio.load();
+    } catch {
+      // Let play surface the final error.
+    }
+
+    try {
+      await audio.play();
+      return true;
+    } catch (error) {
+      this.patchState({
+        playing: false,
+        analysisAvailable: false,
+        error: getPlaybackErrorMessage(error),
+      });
+      return false;
+    } finally {
+      this.playbackFallbackInProgress = false;
+    }
+  }
+
+  private playDirectPlaybackFallback(): Promise<boolean> {
+    if (this.playbackFallbackPromise) {
+      return this.playbackFallbackPromise;
+    }
+
+    const fallbackPromise = this.performDirectPlaybackFallback();
+    const trackedPromise = fallbackPromise.finally(() => {
+      if (this.playbackFallbackPromise === trackedPromise) {
+        this.playbackFallbackPromise = null;
+      }
+    });
+    this.playbackFallbackPromise = trackedPromise;
+    return trackedPromise;
+  }
+
   private async ensureAnalysisGraph(): Promise<boolean> {
+    if (!this.analysisEnabledForCurrentAudio) {
+      return false;
+    }
+
     const createAudioContext = this.getAudioContextFactory();
 
     if (!createAudioContext) {
@@ -612,23 +749,30 @@ export class CanvasAudioPlaybackService {
         this.audioContext = createAudioContext();
       }
 
-      if (!this.mediaElementSource) {
-        this.mediaElementSource = this.audioContext.createMediaElementSource(audio);
-      }
-
       if (!this.analyserNode) {
         this.analyserNode = this.audioContext.createAnalyser();
         this.analyserNode.fftSize = ANALYSIS_FFT_SIZE;
         this.analyserNode.smoothingTimeConstant = 0.82;
-        this.mediaElementSource.connect(this.analyserNode);
         this.analyserNode.connect(this.audioContext.destination);
       }
 
-      if (!this.analyserData || this.analyserData.length !== this.analyserNode.frequencyBinCount) {
+      if (!this.mediaElementSource) {
+        this.mediaElementSource =
+          this.audioContext.createMediaElementSource(audio);
+        this.mediaElementSource.connect(this.analyserNode);
+      }
+
+      if (
+        !this.analyserData ||
+        this.analyserData.length !== this.analyserNode.frequencyBinCount
+      ) {
         this.analyserData = new Uint8Array(this.analyserNode.frequencyBinCount);
       }
 
-      if (!this.timeDomainData || this.timeDomainData.length !== this.analyserNode.fftSize) {
+      if (
+        !this.timeDomainData ||
+        this.timeDomainData.length !== this.analyserNode.fftSize
+      ) {
         this.timeDomainData = new Uint8Array(this.analyserNode.fftSize);
       }
 
@@ -644,15 +788,19 @@ export class CanvasAudioPlaybackService {
 
   private normalizeBandRanges(length: number): Array<[number, number]> {
     return Array.from({ length: ANALYSIS_BAND_COUNT }, (_, index) => {
-      const start = Math.floor(((index / ANALYSIS_BAND_COUNT) ** 1.85) * length);
-      const end = Math.floor((((index + 1) / ANALYSIS_BAND_COUNT) ** 1.85) * length);
+      const start = Math.floor((index / ANALYSIS_BAND_COUNT) ** 1.85 * length);
+      const end = Math.floor(
+        ((index + 1) / ANALYSIS_BAND_COUNT) ** 1.85 * length
+      );
       return [start, Math.max(start + 1, end)];
     });
   }
 
-  private readSpectrumLevels():
-    | { levels: number[]; waveformLevels: number[]; pulseLevel: number }
-    | null {
+  private readSpectrumLevels(): {
+    levels: number[];
+    waveformLevels: number[];
+    pulseLevel: number;
+  } | null {
     if (!this.analyserNode || !this.analyserData || !this.timeDomainData) {
       return null;
     }
@@ -674,8 +822,8 @@ export class CanvasAudioPlaybackService {
       { length: ANALYSIS_WAVEFORM_SAMPLE_COUNT },
       (_, index) => {
         const position = Math.round(
-          (index / Math.max(1, ANALYSIS_WAVEFORM_SAMPLE_COUNT - 1))
-            * (timeDomainData.length - 1)
+          (index / Math.max(1, ANALYSIS_WAVEFORM_SAMPLE_COUNT - 1)) *
+            (timeDomainData.length - 1)
         );
         const start = Math.max(0, position - 1);
         const end = Math.min(timeDomainData.length, position + 2);
@@ -687,7 +835,8 @@ export class CanvasAudioPlaybackService {
 
         const average = total / Math.max(1, end - start);
         const emphasized =
-          Math.sign(average) * Math.min(1, Math.pow(Math.abs(average), 0.88) * 1.72);
+          Math.sign(average) *
+          Math.min(1, Math.pow(Math.abs(average), 0.88) * 1.72);
 
         return Math.max(-1, Math.min(1, emphasized));
       }
@@ -695,19 +844,22 @@ export class CanvasAudioPlaybackService {
     const waveformLevels = rawWaveformLevels.map((sample, index, values) => {
       const previous = values[index - 1] ?? sample;
       const next = values[index + 1] ?? sample;
-      return Math.max(-1, Math.min(1, previous * 0.2 + sample * 0.6 + next * 0.2));
+      return Math.max(
+        -1,
+        Math.min(1, previous * 0.2 + sample * 0.6 + next * 0.2)
+      );
     });
     const waveformEnergy =
-      waveformLevels.reduce((total, sample) => total + Math.abs(sample), 0)
-      / Math.max(1, waveformLevels.length);
+      waveformLevels.reduce((total, sample) => total + Math.abs(sample), 0) /
+      Math.max(1, waveformLevels.length);
     const pulseLevel = Math.max(
       0,
       Math.min(
         1,
-        (levels[0] ?? 0) * 0.42
-          + (levels[1] ?? 0) * 0.28
-          + (levels[2] ?? 0) * 0.16
-          + waveformEnergy * 0.22
+        (levels[0] ?? 0) * 0.42 +
+          (levels[1] ?? 0) * 0.28 +
+          (levels[2] ?? 0) * 0.16 +
+          waveformEnergy * 0.22
       )
     );
 
@@ -725,7 +877,12 @@ export class CanvasAudioPlaybackService {
     this.lastAnalysisFrameAt = 0;
 
     const step = (timestamp: number) => {
-      if (!this.analyserNode || !this.analyserData || !this.state.playing || this.state.mediaType !== 'audio') {
+      if (
+        !this.analyserNode ||
+        !this.analyserData ||
+        !this.state.playing ||
+        this.state.mediaType !== 'audio'
+      ) {
         this.analysisFrameHandle = null;
         return;
       }
@@ -739,18 +896,33 @@ export class CanvasAudioPlaybackService {
             analysisAvailable: true,
             spectrumLevels: nextSpectrum.levels.map((level, index) => {
               const previous = current.spectrumLevels[index] ?? 0;
-              return Math.max(0, Math.min(1, previous * ANALYSIS_SMOOTHING + level * (1 - ANALYSIS_SMOOTHING)));
+              return Math.max(
+                0,
+                Math.min(
+                  1,
+                  previous * ANALYSIS_SMOOTHING +
+                    level * (1 - ANALYSIS_SMOOTHING)
+                )
+              );
             }),
             waveformLevels: nextSpectrum.waveformLevels.map((sample, index) => {
               const previous = current.waveformLevels[index] ?? 0;
               return Math.max(
                 -1,
-                Math.min(1, previous * WAVEFORM_SMOOTHING + sample * (1 - WAVEFORM_SMOOTHING))
+                Math.min(
+                  1,
+                  previous * WAVEFORM_SMOOTHING +
+                    sample * (1 - WAVEFORM_SMOOTHING)
+                )
               );
             }),
             pulseLevel: Math.max(
               0,
-              Math.min(1, current.pulseLevel * PULSE_SMOOTHING + nextSpectrum.pulseLevel * (1 - PULSE_SMOOTHING))
+              Math.min(
+                1,
+                current.pulseLevel * PULSE_SMOOTHING +
+                  nextSpectrum.pulseLevel * (1 - PULSE_SMOOTHING)
+              )
             ),
           }));
         }
@@ -804,22 +976,38 @@ export class CanvasAudioPlaybackService {
   private startReadingProgressLoop(): void {
     this.stopReadingProgressLoop();
     const setIntervalFn = this.getSetInterval();
-    if (!setIntervalFn || !this.currentReadingSource || this.state.activeReadingSegmentIndex < 0) {
+    if (
+      !setIntervalFn ||
+      !this.currentReadingSource ||
+      this.state.activeReadingSegmentIndex < 0
+    ) {
       return;
     }
 
     this.readingProgressHandle = setIntervalFn(() => {
-      if (!this.currentReadingSource || this.state.activeReadingSegmentIndex < 0 || !this.state.playing) {
+      if (
+        !this.currentReadingSource ||
+        this.state.activeReadingSegmentIndex < 0 ||
+        !this.state.playing
+      ) {
         return;
       }
 
-      const segment = this.currentReadingSource.segments[this.state.activeReadingSegmentIndex];
+      const segment =
+        this.currentReadingSource.segments[
+          this.state.activeReadingSegmentIndex
+        ];
       if (!segment) {
         return;
       }
 
-      const elapsedMs = this.readingSegmentOffsetMs + Math.max(0, this.getNow() - this.readingSegmentResumeAt);
-      const currentTimeMs = Math.min(segment.endMs, segment.startMs + elapsedMs);
+      const elapsedMs =
+        this.readingSegmentOffsetMs +
+        Math.max(0, this.getNow() - this.readingSegmentResumeAt);
+      const currentTimeMs = Math.min(
+        segment.endMs,
+        segment.startMs + elapsedMs
+      );
       this.patchState({
         currentTime: currentTimeMs / 1000,
       });
@@ -871,16 +1059,33 @@ export class CanvasAudioPlaybackService {
     restartFromBeginning = false
   ): Promise<void> {
     this.stopReadingForAudio();
-    const audio = this.ensureAudio();
+    let audio = this.ensureAudio();
     const playbackUrl = await this.resolvePlaybackAudioUrl(source);
     const switchingTrack =
-      restartFromBeginning
-      || this.state.activeAudioUrl !== source.audioUrl
-      || this.state.mediaType !== 'audio';
+      restartFromBeginning ||
+      this.state.activeAudioUrl !== source.audioUrl ||
+      this.state.mediaType !== 'audio';
     const activeQueueIndex = this.findQueueIndex(this.state.queue, source);
 
     if (switchingTrack) {
       audio.pause();
+      const resolvedToLocalCache = playbackUrl !== source.audioUrl;
+      const directRemotePlayback = /^https?:\/\//i.test(playbackUrl);
+      if (directRemotePlayback && this.mediaElementSource) {
+        this.replaceAudioElementForDirectPlayback();
+        audio = this.ensureAudio();
+      }
+      this.analysisEnabledForCurrentAudio = !directRemotePlayback;
+      this.directPlaybackFallbackUrl =
+        resolvedToLocalCache && /^https?:\/\//i.test(source.audioUrl)
+          ? source.audioUrl
+          : null;
+      this.playbackFallbackInProgress = false;
+      if (/^https?:\/\//i.test(playbackUrl)) {
+        audio.removeAttribute('crossorigin');
+      } else {
+        audio.crossOrigin = 'anonymous';
+      }
       audio.src = playbackUrl;
       audio.currentTime = 0;
 
@@ -904,7 +1109,9 @@ export class CanvasAudioPlaybackService {
       activeClipIds: source.clipIds,
       activeQueueIndex,
       currentTime: switchingTrack ? 0 : audio.currentTime,
-      duration: source.duration || (Number.isFinite(audio.duration) ? audio.duration : 0),
+      duration:
+        source.duration ||
+        (Number.isFinite(audio.duration) ? audio.duration : 0),
       effectivePlaybackRate: this.state.audioPlaybackRate,
       activeReadingSourceId: undefined,
       activeReadingOrigin: undefined,
@@ -921,10 +1128,18 @@ export class CanvasAudioPlaybackService {
     try {
       await audio.play();
     } catch (error) {
-      this.patchState({
-        playing: false,
-        error: getPlaybackErrorMessage(error),
-      });
+      const fallbackWasAvailable = Boolean(
+        this.directPlaybackFallbackUrl || this.playbackFallbackPromise
+      );
+      if (await this.playDirectPlaybackFallback()) {
+        return;
+      }
+      if (!fallbackWasAvailable) {
+        this.patchState({
+          playing: false,
+          error: getPlaybackErrorMessage(error),
+        });
+      }
       throw error;
     }
   }
@@ -952,19 +1167,25 @@ export class CanvasAudioPlaybackService {
         ext !== 'bin' ? ext : 'mp3',
         undefined,
         {
-          source:
-            source.elementId?.startsWith('asset:')
-              ? 'PLAYBACK_CACHE'
-              : 'AI_GENERATED',
+          source: source.elementId?.startsWith('asset:')
+            ? 'PLAYBACK_CACHE'
+            : 'AI_GENERATED',
+          returnLocalCacheUrl: true,
         }
       );
     } catch (error) {
-      console.warn('[CanvasAudioPlayback] Failed to resolve local audio cache:', error);
+      console.warn(
+        '[CanvasAudioPlayback] Failed to resolve local audio cache:',
+        error
+      );
       return audioUrl;
     }
   }
 
-  private createReadingUtterance(text: string, preferredLanguage: string): SpeechSynthesisUtterance | null {
+  private createReadingUtterance(
+    text: string,
+    preferredLanguage: string
+  ): SpeechSynthesisUtterance | null {
     const speechSynthesis = this.getSpeechSynthesis();
     const utteranceFactory = this.getUtteranceFactory();
     if (!speechSynthesis || !utteranceFactory) {
@@ -983,7 +1204,11 @@ export class CanvasAudioPlaybackService {
     utterance.rate = settings.rate;
     utterance.pitch = settings.pitch;
     utterance.volume = settings.volume;
-    const voice = resolveVoice(speechSynthesis.getVoices(), settings, preferredLanguage);
+    const voice = resolveVoice(
+      speechSynthesis.getVoices(),
+      settings,
+      preferredLanguage
+    );
     if (voice) {
       utterance.voice = voice;
     }
@@ -1014,7 +1239,10 @@ export class CanvasAudioPlaybackService {
       return;
     }
 
-    const utterance = this.createReadingUtterance(segment.text, source.preferredLanguage);
+    const utterance = this.createReadingUtterance(
+      segment.text,
+      source.preferredLanguage
+    );
     if (!utterance) {
       this.patchState({
         playing: false,
@@ -1068,7 +1296,8 @@ export class CanvasAudioPlaybackService {
       readingSegments: source.segments,
       subtitleMode: 'estimated',
       currentTime: segment.startMs / 1000,
-      duration: (source.segments[source.segments.length - 1]?.endMs || 0) / 1000,
+      duration:
+        (source.segments[source.segments.length - 1]?.endMs || 0) / 1000,
       effectivePlaybackRate: this.state.readingPlaybackRate,
       playing: true,
       analysisAvailable: false,
@@ -1096,13 +1325,17 @@ export class CanvasAudioPlaybackService {
       activeQueueIndex,
     });
 
-    this.beginReadingSegment(source, Math.max(0, Math.min(segmentIndex, source.segments.length - 1)));
+    this.beginReadingSegment(
+      source,
+      Math.max(0, Math.min(segmentIndex, source.segments.length - 1))
+    );
   }
 
   async togglePlayback(source: CanvasAudioPlaybackSource): Promise<void> {
-    const isSameTrack = this.state.mediaType === 'audio'
-      && this.state.activeElementId === source.elementId
-      && this.state.activeAudioUrl === source.audioUrl;
+    const isSameTrack =
+      this.state.mediaType === 'audio' &&
+      this.state.activeElementId === source.elementId &&
+      this.state.activeAudioUrl === source.audioUrl;
 
     if (isSameTrack && this.state.playing) {
       this.pausePlayback();
@@ -1113,8 +1346,9 @@ export class CanvasAudioPlaybackService {
   }
 
   toggleReadingPlayback(source: ReadingPlaybackSource): void {
-    const isSameSource = this.state.mediaType === 'reading'
-      && this.state.activeReadingSourceId === source.readingSourceId;
+    const isSameSource =
+      this.state.mediaType === 'reading' &&
+      this.state.activeReadingSourceId === source.readingSourceId;
 
     if (isSameSource) {
       if (this.state.playing) {
@@ -1147,11 +1381,16 @@ export class CanvasAudioPlaybackService {
       this.patchState((current) => ({
         readingPlaybackRate: nextRate,
         effectivePlaybackRate:
-          current.mediaType !== 'audio' ? nextRate : current.effectivePlaybackRate,
+          current.mediaType !== 'audio'
+            ? nextRate
+            : current.effectivePlaybackRate,
       }));
 
       if (this.state.mediaType === 'reading' && this.currentReadingSource) {
-        const nextSegmentIndex = Math.max(0, this.state.activeReadingSegmentIndex);
+        const nextSegmentIndex = Math.max(
+          0,
+          this.state.activeReadingSegmentIndex
+        );
         if (this.state.playing) {
           this.startReading(this.currentReadingSource, nextSegmentIndex);
         } else {
@@ -1160,7 +1399,10 @@ export class CanvasAudioPlaybackService {
       }
 
       void ttsSettings.update({ rate: nextRate }).catch((error) => {
-        console.warn('[CanvasAudioPlayback] Failed to persist reading playback rate:', error);
+        console.warn(
+          '[CanvasAudioPlayback] Failed to persist reading playback rate:',
+          error
+        );
       });
       return;
     }
@@ -1178,7 +1420,9 @@ export class CanvasAudioPlaybackService {
     this.patchState((current) => ({
       audioPlaybackRate: nextRate,
       effectivePlaybackRate:
-        current.mediaType !== 'reading' ? nextRate : current.effectivePlaybackRate,
+        current.mediaType !== 'reading'
+          ? nextRate
+          : current.effectivePlaybackRate,
     }));
   }
 
@@ -1230,7 +1474,10 @@ export class CanvasAudioPlaybackService {
     return -1;
   }
 
-  private async playQueueItemAt(index: number, restartFromBeginning = false): Promise<void> {
+  private async playQueueItemAt(
+    index: number,
+    restartFromBeginning = false
+  ): Promise<void> {
     if (index < 0 || index >= this.state.queue.length) {
       return;
     }
@@ -1252,7 +1499,10 @@ export class CanvasAudioPlaybackService {
       return;
     }
 
-    await this.playQueueItemAt(nextIndex, nextIndex === this.state.activeQueueIndex);
+    await this.playQueueItemAt(
+      nextIndex,
+      nextIndex === this.state.activeQueueIndex
+    );
   }
 
   setCanvasQueue(queue: CanvasAudioPlaybackSource[]): void {
@@ -1264,10 +1514,10 @@ export class CanvasAudioPlaybackService {
     }
 
     const activeSource = this.state.activeAudioUrl
-      ? {
+      ? ({
           elementId: this.state.activeElementId,
           audioUrl: this.state.activeAudioUrl,
-        } as CanvasAudioPlaybackSource
+        } as CanvasAudioPlaybackSource)
       : null;
 
     const activeQueueIndex = activeSource
@@ -1304,7 +1554,9 @@ export class CanvasAudioPlaybackService {
   ): void {
     const normalizedQueue = this.normalizeQueue(queue);
     const activeSource = this.state.activeReadingSourceId
-      ? normalizedQueue.find((item) => item.readingSourceId === this.state.activeReadingSourceId)
+      ? normalizedQueue.find(
+          (item) => item.readingSourceId === this.state.activeReadingSourceId
+        )
       : null;
 
     this.patchState({
@@ -1312,7 +1564,9 @@ export class CanvasAudioPlaybackService {
       activePlaylistId: options?.queueId,
       activePlaylistName: options?.queueName,
       queue: normalizedQueue,
-      activeQueueIndex: activeSource ? this.findQueueIndex(normalizedQueue, activeSource) : -1,
+      activeQueueIndex: activeSource
+        ? this.findQueueIndex(normalizedQueue, activeSource)
+        : -1,
     });
   }
 
@@ -1343,20 +1597,26 @@ export class CanvasAudioPlaybackService {
       this.canvasQueue = normalizedQueue.filter(isAudioPlaybackSource);
     }
     const activeSource = this.state.activeAudioUrl
-      ? {
+      ? ({
           elementId: this.state.activeElementId,
           audioUrl: this.state.activeAudioUrl,
-        } as CanvasAudioPlaybackSource
+        } as CanvasAudioPlaybackSource)
       : null;
 
     this.patchState({
       queueSource: options?.queueSource || 'canvas',
       activePlaylistId:
-        options?.queueId ?? (options?.queueSource === 'playlist' ? options.playlistId : undefined),
+        options?.queueId ??
+        (options?.queueSource === 'playlist' ? options.playlistId : undefined),
       activePlaylistName:
-        options?.queueName ?? (options?.queueSource === 'playlist' ? options.playlistName : undefined),
+        options?.queueName ??
+        (options?.queueSource === 'playlist'
+          ? options.playlistName
+          : undefined),
       queue: normalizedQueue,
-      activeQueueIndex: activeSource ? this.findQueueIndex(normalizedQueue, activeSource) : -1,
+      activeQueueIndex: activeSource
+        ? this.findQueueIndex(normalizedQueue, activeSource)
+        : -1,
     });
   }
 
@@ -1369,7 +1629,10 @@ export class CanvasAudioPlaybackService {
 
       speechSynthesis.pause();
       if (this.readingSegmentResumeAt > 0) {
-        this.readingSegmentOffsetMs += Math.max(0, this.getNow() - this.readingSegmentResumeAt);
+        this.readingSegmentOffsetMs += Math.max(
+          0,
+          this.getNow() - this.readingSegmentResumeAt
+        );
       }
       this.readingSegmentResumeAt = 0;
       this.stopReadingProgressLoop();
@@ -1411,7 +1674,10 @@ export class CanvasAudioPlaybackService {
         return;
       }
 
-      if (this.state.activeReadingSegmentIndex < 0 || this.readingResumeRequiresRestart) {
+      if (
+        this.state.activeReadingSegmentIndex < 0 ||
+        this.readingResumeRequiresRestart
+      ) {
         this.startReading(
           this.currentReadingSource,
           Math.max(0, this.state.activeReadingSegmentIndex)
@@ -1468,7 +1734,10 @@ export class CanvasAudioPlaybackService {
       return;
     }
 
-    const boundedIndex = Math.max(0, Math.min(index, this.currentReadingSource.segments.length - 1));
+    const boundedIndex = Math.max(
+      0,
+      Math.min(index, this.currentReadingSource.segments.length - 1)
+    );
     this.startReading(this.currentReadingSource, boundedIndex);
   }
 
@@ -1487,6 +1756,7 @@ export class CanvasAudioPlaybackService {
   stopAndClear(): void {
     this.stopAnalysisLoop();
     this.clearReadingRuntime(true);
+    this.directPlaybackFallbackUrl = null;
 
     if (this.audio) {
       this.audio.pause();

--- a/packages/drawnix/src/services/generation-api-service.ts
+++ b/packages/drawnix/src/services/generation-api-service.ts
@@ -779,6 +779,7 @@ class GenerationAPIService {
           modelRef: requestedModelRef || null,
           title: params.title,
           tags: params.tags,
+          instrumental: params.instrumental,
           mv: params.mv,
           sunoAction: params.sunoAction,
           notifyHook: params.notifyHook,

--- a/packages/drawnix/src/services/model-adapters/custom-http-adapter.ts
+++ b/packages/drawnix/src/services/model-adapters/custom-http-adapter.ts
@@ -295,6 +295,8 @@ export const customHttpAudioAdapter: AudioModelAdapter = {
         ...(request.params || {}),
         title: request.title,
         tags: request.tags,
+        instrumental: request.instrumental,
+        make_instrumental: request.instrumental,
         mv: request.mv,
         sunoAction: request.sunoAction,
         notifyHook: request.notifyHook,

--- a/packages/drawnix/src/services/model-adapters/default-adapters.ts
+++ b/packages/drawnix/src/services/model-adapters/default-adapters.ts
@@ -322,6 +322,7 @@ export const sunoAudioAdapter: AudioModelAdapter = {
         prompt: request.prompt,
         title: request.title,
         tags: request.tags,
+        instrumental: request.instrumental,
         mv: request.mv,
         sunoAction: request.sunoAction,
         notifyHook: request.notifyHook,

--- a/packages/drawnix/src/services/model-adapters/types.ts
+++ b/packages/drawnix/src/services/model-adapters/types.ts
@@ -99,6 +99,7 @@ export interface AudioGenerationRequest {
   modelRef?: ModelRef | null;
   title?: string;
   tags?: string;
+  instrumental?: boolean;
   mv?: string;
   sunoAction?: string;
   notifyHook?: string;

--- a/packages/drawnix/src/services/sw-capabilities/types.ts
+++ b/packages/drawnix/src/services/sw-capabilities/types.ts
@@ -232,6 +232,7 @@ export interface AudioGenerationParams {
   notifyHook?: string;
   title?: string;
   tags?: string;
+  instrumental?: boolean;
   mv?: string;
   continueClipId?: string;
   continueTaskId?: string;

--- a/packages/drawnix/src/services/task-queue-service.ts
+++ b/packages/drawnix/src/services/task-queue-service.ts
@@ -900,6 +900,7 @@ class TaskQueueService {
             modelRef: requestedModelRef,
             title: task.params.title,
             tags: task.params.tags,
+            instrumental: task.params.instrumental,
             mv: task.params.mv,
             sunoAction: task.params.sunoAction,
             notifyHook: task.params.notifyHook,

--- a/packages/drawnix/src/types/shared/core.types.ts
+++ b/packages/drawnix/src/types/shared/core.types.ts
@@ -213,6 +213,8 @@ export interface GenerationParams {
   title?: string;
   /** Audio style tags */
   tags?: string;
+  /** Whether Suno should generate instrumental-only audio */
+  instrumental?: boolean;
   /** Audio model version */
   mv?: string;
   /** Suno action type (e.g. music or lyrics) */


### PR DESCRIPTION
## 背景

Suno 音乐链路存在三个相互关联的问题：

- 纯音乐请求在部分入口没有稳定传递 `instrumental`，容易生成带人声甚至英语朗诵的结果。
- Suno 一次任务返回两首音乐时，任务队列和媒体预览主要暴露第一首，第二首缺少明确入口。
- 同一音频在任务队列原生播放器中可以播放，但插入画布后偶发无法播放或处于播放状态却没有声音。

## 根因

1. Suno 请求参数在页面状态、任务参数、模型适配器和 MCP 工具之间没有完整贯通纯音乐标志。
2. 返回值解析对嵌套 `data`、状态字段和多 clip 结构兼容不足，部分路径只保留单一 URL。
3. 任务卡片和媒体预览缺少多音轨展示、逐首打开及下载入口。
4. 画布播放器优先经过缓存和 Web Audio 分析：
   - 缓存 URL 的 `audio.play()` Promise 直接拒绝时，旧逻辑不会回退原始远程 URL。
   - 无 CORS 的远程音频接入 `MediaElementSource` 后可能被浏览器静音。
   - 已绑定分析图的共享音频元素回退到远程 URL 后，旧分析链路仍可能继续影响声音输出。

## 修改内容

### 纯音乐参数贯通

- 在音乐分析记录、生成页面、歌词页面和任务参数中增加并持久化 `instrumental`。
- 为纯音乐模式增加明确开关和提示文案。
- 将 `instrumental` 贯通到默认/自定义模型适配器、生成 API、MCP 音频工具和共享类型。
- 补充 Suno 模型能力声明，确保兼容参数过滤不会丢弃该字段。

### Suno 多结果解析与展示

- 兼容 Suno 提交与轮询接口的多种嵌套响应结构、字符串任务 ID 和状态别名。
- 保留并规范化完整 clip 列表、音频 URL、封面、时长、clip ID 与 provider task ID。
- 任务队列对多首结果显示数量，并提供“查看全部”入口。
- 媒体预览支持多音轨切换、逐首播放、下载、插入画布和打开原始链接。
- 避免多个任务队列容器重复渲染同一任务详情入口。

### 画布播放可靠性

- 画布播放优先请求本地稳定缓存 URL，降低签名地址过期和跨域播放差异。
- 将 `error` 事件与 `audio.play()` Promise 拒绝统一到一次性远程 URL 回退路径。
- 若音频元素已经绑定 Web Audio 分析图，回退前替换为新的 `HTMLAudioElement` 并解绑旧节点。
- 直接远程播放时关闭 Web Audio 分析，优先保证声音正常输出；本地缓存音频仍保留频谱和波形分析。
- 最终远程播放失败时停止重试并保留可读错误状态。

## 验证

### 自动化测试

- 相关回归：4 个测试文件，92 项全部通过。
- `canvas-audio-playback-service.test.ts` 新增覆盖：
  - 缓存播放拒绝后回退原始 URL。
  - 已绑定分析图时替换音频元素。
  - 远程直链不创建 Web Audio 分析图但仍可播放。
  - 最终远程失败不会循环重试。
- `pnpm --dir packages/drawnix exec tsc --noEmit --pretty false` 通过。
- 全部改动文件 Prettier 检查通过。
- `git diff --check` 通过。

### 真实链路验收

- 使用本地配置的真实 Suno API 生成成功，返回 2 首纯音乐。
- 两首音频时长约为 43.48 秒和 58.04 秒，远程资源均返回 HTTP 200，并可由 `ffprobe` 解码。
- 任务卡正确显示“查看全部 2 首”。
- 在真实画布中分别播放两首音乐：第一首进度推进至 `0:13/0:43`，切换第二首后推进至 `0:02/0:58`。
- 刷新页面后再次播放，进度正常推进，未出现音频加载错误或控制台播放错误。

### 仓库整包测试现状

执行 `pnpm --dir packages/drawnix test`：

- Test Files：225 passed，1 skipped，7 failed。
- Tests：2085 passed，1 skipped，48 failed。
- 失败集中在未修改的工作区 IndexedDB 初始化、AI 输入解析、工作流音频导出测试，以及一个既有 mock 缺少 `isAvailable()` 的未处理异常；本 PR 直接相关测试均通过。

## 风险与取舍

- 当本地缓存不可用并回退无 CORS 远程直链时，播放器会关闭实时频谱分析。这是有意取舍：保证可听和可控制优先于可视化效果。
- 远程回退只执行一次，避免失效 URL 引发无限加载循环。
- 改动不包含 API Key、用户数据或持久化凭据。
