### PR TITLE
feat: add Tuzi URL token integration mode

### DIFF
--- a/apps/web/src/app/bootstrap.tsx
+++ b/apps/web/src/app/bootstrap.tsx
@@ -16,7 +16,12 @@ import {
   swChannelClient,
   safeReload,
 } from '@drawnix/drawnix/runtime';
-import { analytics } from '@drawnix/drawnix';
+import {
+  analytics,
+  getAnalyticsReleaseContext,
+  isTuziUrlTokenMode,
+  registerAnalyticsSuperProperties,
+} from '@drawnix/drawnix';
 import { initSWConsoleCapture } from '../utils/sw-console-capture';
 
 const isLocalDev =
@@ -28,10 +33,13 @@ const swQueryParam =
     ? new URLSearchParams(window.location.search).get('sw')
     : null;
 const isServiceWorkerExplicitlyDisabled = swQueryParam === '0';
+const isTuziUrlToken = isTuziUrlTokenMode();
 const hasServiceWorkerSupport =
   typeof navigator !== 'undefined' && 'serviceWorker' in navigator;
 const shouldUseServiceWorker =
-  hasServiceWorkerSupport && !isServiceWorkerExplicitlyDisabled;
+  hasServiceWorkerSupport &&
+  !isServiceWorkerExplicitlyDisabled &&
+  !isTuziUrlToken;
 
 // ===== 控制台日志捕获（尽早初始化，确保默认 console 被改写） =====
 // 必须在其他业务代码之前执行，否则后续工具（如 rrweb）可能先改写 console 导致捕获失效
@@ -243,7 +251,10 @@ if (typeof window !== 'undefined') {
   });
 }
 
-if (hasServiceWorkerSupport && isServiceWorkerExplicitlyDisabled) {
+if (
+  hasServiceWorkerSupport &&
+  (isServiceWorkerExplicitlyDisabled || isTuziUrlToken)
+) {
   cleanupDisabledServiceWorker();
 }
 

--- a/packages/drawnix/src/services/__tests__/tuzi-url-token.test.ts
+++ b/packages/drawnix/src/services/__tests__/tuzi-url-token.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getTuziUrlApiKeyFromHref,
+  isTuziUrlTokenMode,
+} from '../provider-routing/tuzi-url-token';
+
+const token = 'sk-tuzi-runtime-token';
+
+describe('tuzi URL token bridge', () => {
+  it('reads the dedicated query parameter', () => {
+    expect(
+      getTuziUrlApiKeyFromHref(
+        `https://opentu.example.com/?tuzi_api_key=${token}`
+      )
+    ).toBe(token);
+  });
+
+  it('reads the dedicated hash parameter', () => {
+    expect(
+      getTuziUrlApiKeyFromHref(
+        `https://opentu.example.com/#tuzi_api_key=${token}`
+      )
+    ).toBe(token);
+  });
+
+  it('does not treat the existing apiKey import parameter as runtime mode', () => {
+    expect(
+      getTuziUrlApiKeyFromHref(`https://opentu.example.com/?apiKey=${token}`)
+    ).toBe('');
+  });
+
+  it('rejects values that are not model API tokens', () => {
+    expect(
+      getTuziUrlApiKeyFromHref(
+        'https://opentu.example.com/?tuzi_api_key=not-a-model-token'
+      )
+    ).toBe('');
+    expect(isTuziUrlTokenMode('https://opentu.example.com/')).toBe(false);
+  });
+
+  it('recognizes URL-token mode only when a valid token is present', () => {
+    expect(
+      isTuziUrlTokenMode(`https://opentu.example.com/#tuzi_api_key=${token}`)
+    ).toBe(true);
+  });
+});

--- a/packages/drawnix/src/services/provider-routing/index.ts
+++ b/packages/drawnix/src/services/provider-routing/index.ts
@@ -2,5 +2,6 @@ export * from './types';
 export * from './provider-transport';
 export * from './invocation-planner';
 export * from './binding-inference';
+export * from './tuzi-url-token';
 export * from './text-binding-capabilities';
 export * from './settings-repository';

--- a/packages/drawnix/src/services/provider-routing/settings-repository.ts
+++ b/packages/drawnix/src/services/provider-routing/settings-repository.ts
@@ -25,6 +25,7 @@ import {
 import { InvocationPlanner } from './invocation-planner';
 import { inferBindingsForProviderCatalog } from './binding-inference';
 import { isTuziCompatibleBaseUrl } from './tuzi-api-endpoints';
+import { getTuziUrlApiKey } from './tuzi-url-token';
 import { modelPricingService } from '../../utils/model-pricing-service';
 import type {
   InvocationPlan,
@@ -72,6 +73,16 @@ function isTuziBaseUrl(baseUrl: string): boolean {
   return isTuziCompatibleBaseUrl(baseUrl);
 }
 
+function resolveRuntimeApiKey(
+  baseUrl: string,
+  configuredApiKey: string
+): string {
+  const runtimeApiKey = getTuziUrlApiKey();
+  return runtimeApiKey && isTuziBaseUrl(baseUrl)
+    ? runtimeApiKey
+    : configuredApiKey;
+}
+
 function inferAuthType(
   baseUrl: string,
   providerType: ProviderProfile['providerType'],
@@ -108,7 +119,7 @@ function toProviderProfileSnapshot(
     name: profile.name,
     providerType: profile.providerType,
     baseUrl: profile.baseUrl,
-    apiKey: profile.apiKey,
+    apiKey: resolveRuntimeApiKey(profile.baseUrl, profile.apiKey),
     authType: inferAuthType(
       profile.baseUrl,
       profile.providerType,
@@ -190,7 +201,7 @@ function buildLegacyProfileSnapshot(): ProviderProfileSnapshot {
     name: TUZI_DEFAULT_PROVIDER_NAME,
     providerType,
     baseUrl,
-    apiKey: gemini.apiKey?.trim() || '',
+    apiKey: resolveRuntimeApiKey(baseUrl, gemini.apiKey?.trim() || ''),
     authType: inferAuthType(
       baseUrl,
       providerType,

--- a/packages/drawnix/src/services/provider-routing/tuzi-url-token.ts
+++ b/packages/drawnix/src/services/provider-routing/tuzi-url-token.ts
@@ -1,0 +1,64 @@
+const TUZI_URL_TOKEN_PARAM = 'tuzi_api_key';
+const TUZI_TOKEN_PREFIX = 'sk-';
+
+function readTokenFromParams(params: URLSearchParams): string {
+  const explicitToken = params.get(TUZI_URL_TOKEN_PARAM)?.trim() || '';
+  if (explicitToken.startsWith(TUZI_TOKEN_PREFIX)) {
+    return explicitToken;
+  }
+
+  return '';
+}
+
+function parseUrl(href: string): URL | null {
+  try {
+    return new URL(href, 'http://localhost');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Reads the temporary Tuzi integration token without persisting it.
+ * The URL is intentionally the source of truth for the development bridge.
+ */
+export function getTuziUrlApiKeyFromHref(href: string): string {
+  const url = parseUrl(href);
+  if (!url) {
+    return '';
+  }
+
+  const searchToken = readTokenFromParams(url.searchParams);
+  if (searchToken) {
+    return searchToken;
+  }
+
+  const hash = url.hash.startsWith('#') ? url.hash.slice(1) : url.hash;
+  if (!hash) {
+    return '';
+  }
+
+  try {
+    return readTokenFromParams(new URLSearchParams(hash));
+  } catch {
+    return '';
+  }
+}
+
+export function getTuziUrlApiKey(): string {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+
+  return getTuziUrlApiKeyFromHref(window.location.href);
+}
+
+/**
+ * URL-token mode must not use the Service Worker: SW configuration is backed
+ * by IndexedDB and cannot safely read a URL-only credential.
+ */
+export function isTuziUrlTokenMode(href?: string): boolean {
+  const resolvedHref =
+    href || (typeof window !== 'undefined' ? window.location.href : '');
+  return Boolean(getTuziUrlApiKeyFromHref(resolvedHref));
+}


### PR DESCRIPTION
## Summary

- add a dedicated `tuzi_api_key` URL token mode for temporary Tuzi API integration
- inject the runtime token only for trusted Tuzi-compatible provider URLs
- bypass and clean up the Service Worker while a URL-only token is active
- add focused coverage for query/hash parsing and invalid token formats

## Validation

- `pnpm exec vitest run packages/drawnix/src/services/__tests__/tuzi-url-token.test.ts`
- `git diff --check`

## Notes

This PR intentionally contains only the URL-token integration commit from `a6fe6c56`; local untracked OpenSpec files were not included.
