### PR TITLE
feat(tuzi): 优化模型加载体验与日志等

### DIFF
--- a/apps/web/src/app/app.tsx
+++ b/apps/web/src/app/app.tsx
@@ -340,10 +340,8 @@ export function App() {
         if (!tuziStartup) {
           setIsLoading(false);
         }
-        await Promise.all([
-          workspaceService.waitForInitialization(),
-          waitForTuziStartup(tuziStartup),
-        ]);
+        await workspaceService.waitForInitialization();
+        void waitForTuziStartup(tuziStartup);
         // 使用 switchBoard 确保加载完整数据
         const currentBoardId = workspaceService.getState().currentBoardId;
         // 验证画板是否存在，防止旧状态中的 currentBoardId 指向不存在的画板
@@ -572,7 +570,8 @@ export function App() {
             });
         }
 
-        await waitForTuziStartup(tuziStartup);
+        // Tuzi 供应商/模型同步在后台进行，不阻塞工作区首屏进入。
+        void waitForTuziStartup(tuziStartup);
       } catch (error) {
         console.error('[App] Initialization failed:', error);
         setInitError(error instanceof Error ? error : new Error(String(error)));
@@ -1026,9 +1025,9 @@ export function App() {
 
 const addDebugLog = async (board: PlaitBoard, value: string) => {
   const { PlaitBoard } = await import('@plait/core');
-  const container = PlaitBoard.getBoardContainer(board).closest('.drawnix') as
-    | HTMLElement
-    | null;
+  const container = PlaitBoard.getBoardContainer(board).closest(
+    '.drawnix'
+  ) as HTMLElement | null;
   if (!container) {
     return;
   }

--- a/openspec/changes/add-tuzi-session-account-workspace/specs/tuzi-session-account/spec.md
+++ b/openspec/changes/add-tuzi-session-account-workspace/specs/tuzi-session-account/spec.md
@@ -57,7 +57,14 @@ The system SHALL derive OpenTu managed Providers from the authenticated user's a
 #### Scenario: First embedded load
 
 - **WHEN** an authenticated embedded user loads OpenTu Provider settings
-- **THEN** Tuzi API SHALL ensure at most one enabled managed Token for each authorized group and OpenTu SHALL synchronize the resulting Provider profile to the fixed Tuzi `/v1` URL
+- **THEN** OpenTu SHALL first display the user's authorized groups without creating managed Tokens
+- **AND** after the user confirms a selection, Tuzi API SHALL ensure at most one enabled managed Token for each selected authorized group and OpenTu SHALL synchronize only the resulting Provider profiles to the fixed Tuzi `/v1` URL
+
+#### Scenario: Unselected authorized group
+
+- **WHEN** an authenticated user does not select an otherwise authorized group during first connection or token replacement
+- **THEN** Tuzi API SHALL NOT create a managed Token for that group
+- **AND** OpenTu SHALL NOT create or display a managed Provider or replacement-Key control for that group
 
 #### Scenario: Unauthorized group
 

--- a/openspec/changes/add-tuzi-session-account-workspace/tasks.md
+++ b/openspec/changes/add-tuzi-session-account-workspace/tasks.md
@@ -21,14 +21,15 @@
 
 ## 4. Managed group Providers
 
-- [x] 4.1 Add Session-authenticated provider catalog and ensure/rotate orchestration using existing Token storage.
+- [x] 4.1 Add Session-authenticated provider catalog and selective ensure/rotate orchestration using existing Token storage.
 - [ ] 4.2 Add idempotency, group authorization, rotation and no-secret-logging tests.
 - [x] 4.3 Read authorized groups and pricing metadata and synchronize existing OpenTu Provider profiles and bindings.
 - [x] 4.4 Add refresh/rotation controls without changing standalone Provider behavior.
+- [x] 4.5 Let users choose authorized groups before first connection or system-token replacement, and create managed Tokens and Providers only for selected groups.
 
 ## 5. Verification
 
 - [x] 5.1 Run focused Go tests and backend build checks.
 - [x] 5.2 Run focused Vitest tests, type checks, and frontend build.
 - [ ] 5.3 Start both local services and verify managed Provider synchronization.
-- [ ] 5.4 Review final diffs and update QA/documentation status.
+- [x] 5.4 Review final diffs and update QA/documentation status.

--- a/packages/drawnix/src/components/ai-input-bar/ModelDropdown.test.tsx
+++ b/packages/drawnix/src/components/ai-input-bar/ModelDropdown.test.tsx
@@ -46,6 +46,12 @@ vi.mock('../../utils/settings-manager', () => ({
   TUZI_ORIGINAL_PROVIDER_PROFILE_ID: 'tuzi-original',
   TUZI_DEFAULT_PROVIDER_NAME: 'Tuzi',
   TUZI_PROVIDER_ICON_URL: 'https://tuzi.example/icon.png',
+  providerCatalogsSettings: {
+    get: () => [],
+    addListener: () => {},
+    removeListener: () => {},
+    update: async () => {},
+  },
   createModelRef: (profileId: string | null, modelId: string) => ({
     profileId,
     modelId,

--- a/packages/drawnix/src/components/ai-input-bar/ModelDropdown.test.tsx
+++ b/packages/drawnix/src/components/ai-input-bar/ModelDropdown.test.tsx
@@ -1,9 +1,31 @@
 // @vitest-environment jsdom
 import React from 'react';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ModelVendor, type ModelConfig } from '../../constants/model-config';
 import { ModelDropdown } from './ModelDropdown';
+
+const { discoverMock, applySelectionMock } = vi.hoisted(() => ({
+  discoverMock: vi.fn(),
+  applySelectionMock: vi.fn(),
+}));
+
+vi.mock('../../utils/runtime-model-discovery', () => ({
+  runtimeModelDiscovery: {
+    getState: () => ({
+      status: 'idle',
+      discoveredModels: [],
+    }),
+    discover: discoverMock,
+    applySelection: applySelectionMock,
+  },
+}));
 
 vi.mock('../../hooks/use-drawnix', () => ({
   useDrawnix: () => ({ setAppState: vi.fn() }),
@@ -53,6 +75,8 @@ vi.mock('../shared/ModelBenchmarkBadge', () => ({
 describe('ModelDropdown', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    discoverMock.mockReset();
+    applySelectionMock.mockReset();
     cleanup();
   });
 
@@ -265,5 +289,65 @@ describe('ModelDropdown', () => {
 
     expect(menu.textContent).toContain('Tuzi Provider');
     expect(menu.textContent).toContain('vip');
+  });
+
+  it('模型查询未完成时强制显示加载动画，完成后移除加载状态', async () => {
+    let resolveDiscovery: ((models: ModelConfig[]) => void) | undefined;
+    discoverMock.mockImplementation(
+      () =>
+        new Promise<ModelConfig[]>((resolve) => {
+          resolveDiscovery = resolve;
+        })
+    );
+
+    const managedModel: ModelConfig = {
+      ...baseModel,
+      sourceProfileId: 'tuzi-managed-default',
+      sourceProfileName: 'Tuzi 默认分组',
+      selectionKey: 'tuzi-managed-default::gpt-image-2',
+    };
+
+    const { container } = render(
+      <ModelDropdown
+        selectedModel={managedModel.id}
+        selectedSelectionKey={managedModel.selectionKey}
+        models={[managedModel]}
+        providerProfilesOverride={[
+          {
+            id: 'tuzi-managed-default',
+            name: 'Tuzi 默认分组',
+            baseUrl: 'https://tuzi.example/v1',
+            apiKey: 'sk-test',
+            enabled: true,
+            providerType: 'openai-compatible',
+            authType: 'bearer',
+          },
+        ]}
+        onSelect={vi.fn()}
+      />
+    );
+
+    fireEvent.mouseDown(
+      container.querySelector(
+        '.model-dropdown__trigger--minimal'
+      ) as HTMLElement
+    );
+
+    expect(discoverMock).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText('正在加载模型...')).toBeTruthy();
+    const loadingStatus = document.querySelector(
+      '.model-dropdown__loading-overlay'
+    ) as HTMLElement;
+    expect(loadingStatus).toBeTruthy();
+    expect(
+      loadingStatus.querySelector('.model-dropdown__loading-icon')
+    ).not.toBeNull();
+
+    resolveDiscovery?.([managedModel]);
+    await waitFor(() => {
+      expect(
+        document.querySelector('.model-dropdown__loading-overlay')
+      ).toBeNull();
+    });
   });
 });

--- a/packages/drawnix/src/components/ai-input-bar/ModelDropdown.tsx
+++ b/packages/drawnix/src/components/ai-input-bar/ModelDropdown.tsx
@@ -15,6 +15,7 @@ import React, {
   useEffect,
   useMemo,
 } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { copyToClipboard } from '../../utils/runtime-helpers';
 import { createPortal } from 'react-dom';
 import {
@@ -22,6 +23,7 @@ import {
   ChevronDown,
   Copy,
   ExternalLink,
+  Loader2,
   Plus,
   Search,
   X,
@@ -72,18 +74,26 @@ import { queueProviderSettingsNavigation } from '../settings-dialog/provider-set
 
 const lazyProviderModelLoads = new Map<string, Promise<void>>();
 
-function ensureProviderModels(profile?: ProviderProfile | null): void {
+function ensureProviderModels(
+  profile?: ProviderProfile | null
+): Promise<void> | null {
   if (
     !profile?.id.startsWith('tuzi-managed-') ||
     !profile.apiKey.trim() ||
     !profile.baseUrl.trim()
   ) {
-    return;
+    return null;
   }
 
   const state = runtimeModelDiscovery.getState(profile.id);
-  if (state.discoveredModels.length > 0 || state.status === 'loading') return;
-  if (lazyProviderModelLoads.has(profile.id)) return;
+  if (state.discoveredModels.length > 0 || state.status === 'loading') {
+    const inFlightLoad =
+      lazyProviderModelLoads.get(profile.id) ||
+      runtimeModelDiscovery.getInFlightDiscovery(profile.id);
+    return inFlightLoad?.then(() => undefined) || null;
+  }
+  const existingLoad = lazyProviderModelLoads.get(profile.id);
+  if (existingLoad) return existingLoad;
 
   const load = runtimeModelDiscovery
     .discover(profile.id, profile.baseUrl, profile.apiKey)
@@ -100,6 +110,7 @@ function ensureProviderModels(profile?: ProviderProfile | null): void {
       lazyProviderModelLoads.delete(profile.id);
     });
   lazyProviderModelLoads.set(profile.id, load);
+  return load;
 }
 
 function normalizeSearchText(value?: string | null): string {
@@ -264,6 +275,10 @@ export const ModelDropdown: React.FC<ModelDropdownProps> = ({
   const [highlightedIndex, setHighlightedIndex] = useState(0);
   const [activeProviderId, setActiveProviderId] = useState<string | null>(null);
   const [activeVendor, setActiveVendor] = useState<string | null>(null);
+  const [loadingProviderId, setLoadingProviderId] = useState<string | null>(
+    null
+  );
+  const loadingRequestRef = useRef(0);
   const {
     contextMenu,
     open: openContextMenuAt,
@@ -282,6 +297,35 @@ export const ModelDropdown: React.FC<ModelDropdownProps> = ({
       ),
     [effectiveProviderProfiles]
   );
+
+  const loadProviderModels = useCallback((profile?: ProviderProfile | null) => {
+    if (profile?.id.startsWith('tuzi-managed-')) {
+      setLoadingProviderId(profile.id);
+    }
+    const load = ensureProviderModels(profile);
+    if (!load || !profile) {
+      if (profile?.id.startsWith('tuzi-managed-')) {
+        setLoadingProviderId(null);
+      }
+      return load;
+    }
+
+    const requestId = loadingRequestRef.current + 1;
+    loadingRequestRef.current = requestId;
+    void load.then(
+      () => {
+        if (loadingRequestRef.current === requestId) {
+          setLoadingProviderId(null);
+        }
+      },
+      () => {
+        if (loadingRequestRef.current === requestId) {
+          setLoadingProviderId(null);
+        }
+      }
+    );
+    return load;
+  }, []);
   const modelOrderMap = useMemo(
     () =>
       new Map(
@@ -341,38 +385,6 @@ export const ModelDropdown: React.FC<ModelDropdownProps> = ({
       null
     );
   }, [activeProvider, activeVendor]);
-
-  // 确保高亮项可见
-  useEffect(() => {
-    if (isOpen && listRef.current) {
-      const highlightedElement = listRef.current.querySelector(
-        `[data-model-index="${highlightedIndex}"]`
-      ) as HTMLElement | null;
-      if (highlightedElement) {
-        const listContainer = listRef.current;
-        const itemTop = highlightedElement.offsetTop;
-        const itemHeight = highlightedElement.offsetHeight;
-        const containerScrollTop = listContainer.scrollTop;
-        const containerHeight = listContainer.offsetHeight;
-        const containerPaddingTop = 4; // 与 SCSS 中的 padding 一致
-
-        if (highlightedIndex === 0) {
-          // 强制滚回到最顶部，处理 padding
-          listContainer.scrollTop = 0;
-        } else if (itemTop - containerPaddingTop < containerScrollTop) {
-          // 在上方不可见
-          listContainer.scrollTop = itemTop - containerPaddingTop;
-        } else if (
-          itemTop + itemHeight >
-          containerScrollTop + containerHeight
-        ) {
-          // 在下方不可见
-          listContainer.scrollTop =
-            itemTop + itemHeight - containerHeight + containerPaddingTop;
-        }
-      }
-    }
-  }, [highlightedIndex, isOpen]);
 
   // 获取当前模型配置
   const currentModel =
@@ -444,6 +456,47 @@ export const ModelDropdown: React.FC<ModelDropdownProps> = ({
     () => (isSearching ? filteredModelList : activeCategory?.models || []),
     [isSearching, filteredModelList, activeCategory]
   );
+  const shouldVirtualizeModels = displayedModels.length > 50;
+  const modelVirtualizer = useVirtualizer({
+    count: shouldVirtualizeModels ? displayedModels.length : 0,
+    getScrollElement: () => listRef.current,
+    estimateSize: () => 72,
+    overscan: 6,
+    getItemKey: (index) => getModelKey(displayedModels[index]),
+  });
+  const virtualItems = shouldVirtualizeModels
+    ? modelVirtualizer.getVirtualItems()
+    : [];
+
+  // 确保键盘高亮项可见；大列表由 virtualizer 负责定位未挂载的模型项。
+  useEffect(() => {
+    if (!isOpen || !listRef.current) return;
+    if (shouldVirtualizeModels) {
+      modelVirtualizer.scrollToIndex(highlightedIndex, { align: 'auto' });
+      return;
+    }
+
+    const highlightedElement = listRef.current.querySelector(
+      `[data-model-index="${highlightedIndex}"]`
+    ) as HTMLElement | null;
+    if (!highlightedElement) return;
+
+    const listContainer = listRef.current;
+    const itemTop = highlightedElement.offsetTop;
+    const itemHeight = highlightedElement.offsetHeight;
+    const containerScrollTop = listContainer.scrollTop;
+    const containerHeight = listContainer.offsetHeight;
+    const containerPaddingTop = 4;
+
+    if (highlightedIndex === 0) {
+      listContainer.scrollTop = 0;
+    } else if (itemTop - containerPaddingTop < containerScrollTop) {
+      listContainer.scrollTop = itemTop - containerPaddingTop;
+    } else if (itemTop + itemHeight > containerScrollTop + containerHeight) {
+      listContainer.scrollTop =
+        itemTop + itemHeight - containerHeight + containerPaddingTop;
+    }
+  }, [highlightedIndex, isOpen, modelVirtualizer, shouldVirtualizeModels]);
 
   // 供应商标签列表（第一列）
   const providerTabs = useMemo(
@@ -490,9 +543,9 @@ export const ModelDropdown: React.FC<ModelDropdownProps> = ({
       const group = providerGroups.find((g) => g.providerId === providerId);
       setActiveVendor(group?.vendorCategories[0]?.vendor ?? null);
       setHighlightedIndex(0);
-      ensureProviderModels(providerProfileMap.get(providerId));
+      loadProviderModels(providerProfileMap.get(providerId));
     },
-    [providerGroups, providerProfileMap]
+    [loadProviderModels, providerGroups, providerProfileMap]
   );
 
   // 切换厂商分类
@@ -599,8 +652,9 @@ export const ModelDropdown: React.FC<ModelDropdownProps> = ({
         if (selectedVendorHint) {
           setActiveVendor(selectedVendorHint);
         }
-        ensureProviderModels(providerProfileMap.get(selectedProviderHint));
-        ensureProviderModels(providerProfileMap.get(nextProviderId));
+        // 预取当前供应商，同时把实际展示的供应商绑定到 loading 覆盖层。
+        void ensureProviderModels(providerProfileMap.get(selectedProviderHint));
+        loadProviderModels(providerProfileMap.get(nextProviderId));
       }
       if (next) {
         // 打开时清空搜索，默认展示当前供应商/分类
@@ -622,6 +676,7 @@ export const ModelDropdown: React.FC<ModelDropdownProps> = ({
       providerGroups,
       providerProfileMap,
       selectedVendorHint,
+      loadProviderModels,
     ]
   );
 
@@ -1088,7 +1143,17 @@ export const ModelDropdown: React.FC<ModelDropdownProps> = ({
                   onScroll={closeContextMenu}
                 >
                   {displayedModels.length > 0 ? (
-                    displayedModels.map((model, index) => {
+                    (shouldVirtualizeModels
+                      ? virtualItems
+                      : displayedModels
+                    ).map((entry, virtualIndex) => {
+                      const index = shouldVirtualizeModels
+                        ? (entry as (typeof virtualItems)[number]).index
+                        : virtualIndex;
+                      const model = displayedModels[index];
+                      const virtualItem = shouldVirtualizeModels
+                        ? (entry as (typeof virtualItems)[number])
+                        : null;
                       const modelKey = getModelKey(model);
                       const isSelected =
                         modelKey === (selectedSelectionKey || selectedModel);
@@ -1097,6 +1162,22 @@ export const ModelDropdown: React.FC<ModelDropdownProps> = ({
                         <div
                           key={modelKey}
                           data-model-index={index}
+                          ref={
+                            virtualItem
+                              ? (node) => modelVirtualizer.measureElement(node)
+                              : undefined
+                          }
+                          style={
+                            virtualItem
+                              ? {
+                                  position: 'absolute',
+                                  top: 0,
+                                  left: 0,
+                                  width: '100%',
+                                  transform: `translateY(${virtualItem.start}px)`,
+                                }
+                              : undefined
+                          }
                           className={`model-dropdown__item ${
                             isSelected ? 'model-dropdown__item--selected' : ''
                           } ${
@@ -1169,7 +1250,37 @@ export const ModelDropdown: React.FC<ModelDropdownProps> = ({
                         : emptyText || 'No matching models'}
                     </div>
                   )}
+                  {shouldVirtualizeModels && displayedModels.length > 0 ? (
+                    <div
+                      aria-hidden="true"
+                      style={{
+                        height: modelVirtualizer.getTotalSize(),
+                        pointerEvents: 'none',
+                      }}
+                    />
+                  ) : null}
                 </div>
+                {loadingProviderId !== null ? (
+                  <div
+                    className="model-dropdown__loading-overlay"
+                    role="status"
+                    aria-live="polite"
+                    aria-label={
+                      language === 'zh' ? '正在加载模型' : 'Loading models'
+                    }
+                  >
+                    <Loader2
+                      className="model-dropdown__loading-icon"
+                      size={18}
+                      aria-hidden="true"
+                    />
+                    <span>
+                      {language === 'zh'
+                        ? '正在加载模型...'
+                        : 'Loading models...'}
+                    </span>
+                  </div>
+                ) : null}
               </div>
             </VendorTabPanel>
           </div>

--- a/packages/drawnix/src/components/ai-input-bar/model-dropdown.scss
+++ b/packages/drawnix/src/components/ai-input-bar/model-dropdown.scss
@@ -332,6 +332,29 @@ $green-health: #10b981;
     min-width: 0;
     display: flex;
     flex-direction: column;
+    position: relative;
+    overflow: hidden;
+  }
+
+  &__loading-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 2;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    color: var(--td-text-color-secondary, #4b5563);
+    background: rgba(255, 255, 255, 0.72);
+    backdrop-filter: blur(1px);
+    font-size: 12px;
+    pointer-events: auto;
+  }
+
+  &__loading-icon {
+    flex-shrink: 0;
+    color: $orange-primary;
+    animation: model-dropdown-spin 0.9s linear infinite;
   }
 
   &__section-header {
@@ -511,6 +534,12 @@ $green-health: #10b981;
   }
 }
 
+@keyframes model-dropdown-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 // Dark mode support
 :root[data-theme='dark'] {
   .model-dropdown {
@@ -567,6 +596,11 @@ $green-health: #10b981;
       background: var(--color-surface-high, #2a2a2a);
       border-bottom-color: var(--color-border, #444);
       color: var(--color-gray-50, #999);
+    }
+
+    &__loading-overlay {
+      color: var(--color-gray-20, #ccc);
+      background: rgba(42, 42, 42, 0.72);
     }
 
     &__search {

--- a/packages/drawnix/src/components/settings-dialog/TuziAccountPanel.test.tsx
+++ b/packages/drawnix/src/components/settings-dialog/TuziAccountPanel.test.tsx
@@ -370,6 +370,43 @@ describe('TuziAccountPanel', () => {
     expect(synchronizeTuziManagedProviders).not.toHaveBeenCalled();
   });
 
+  it('keeps a failed provider-group request distinct from an empty group list', async () => {
+    const { TuziSessionApiError } = await import(
+      '../../services/tuzi-session-api'
+    );
+    const { TuziAccountPanel } = await import('./TuziAccountPanel');
+
+    render(<TuziAccountPanel />);
+    await screen.findByText('可用额度');
+    getProviderGroups.mockRejectedValueOnce(
+      new TuziSessionApiError('REQUEST_FAILED', 'Tuzi API 请求超时，请稍后重试')
+    );
+
+    const tokenInput = document.querySelector('#tuzi-system-token');
+    expect(tokenInput).not.toBeNull();
+    fireEvent.change(tokenInput as HTMLInputElement, {
+      target: { value: 'system-token' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '替换令牌' }));
+
+    expect(await screen.findByText('数据加载失败')).not.toBeNull();
+    expect(screen.queryByText('暂无可用分组')).toBeNull();
+    expect(
+      (
+        screen.getByRole('button', {
+          name: '应用分组并连接',
+        }) as HTMLButtonElement
+      ).disabled
+    ).toBe(true);
+
+    fireEvent.click(screen.getByRole('button', { name: '重试' }));
+
+    expect(
+      await screen.findByRole('checkbox', { name: /default/ })
+    ).not.toBeNull();
+    expect(screen.queryByText('数据加载失败')).toBeNull();
+  });
+
   it('refreshes the visible account and managed groups after replacing the token', async () => {
     const onProvidersChanged = vi.fn();
     const { TuziAccountPanel } = await import('./TuziAccountPanel');

--- a/packages/drawnix/src/components/settings-dialog/TuziAccountPanel.test.tsx
+++ b/packages/drawnix/src/components/settings-dialog/TuziAccountPanel.test.tsx
@@ -8,6 +8,7 @@ import {
   waitFor,
 } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TuziDisplayConfig } from '../../services/tuzi-session-api';
 
 const {
   ensureManagedProviders,
@@ -15,6 +16,7 @@ const {
   getDisplayConfig,
   getLogs,
   getModels,
+  getProviderGroups,
   getUsageSummary,
   getProfiles,
   rotateManagedProvider,
@@ -26,6 +28,7 @@ const {
   getDisplayConfig: vi.fn(),
   getLogs: vi.fn(),
   getModels: vi.fn(),
+  getProviderGroups: vi.fn(),
   getUsageSummary: vi.fn(),
   getProfiles: vi.fn(),
   rotateManagedProvider: vi.fn(),
@@ -50,6 +53,7 @@ vi.mock('../../services/tuzi-session-api', () => ({
     getDisplayConfig,
     getLogs,
     getModels,
+    getProviderGroups,
     getUsageSummary,
     rotateManagedProvider,
   })),
@@ -115,7 +119,7 @@ describe('TuziAccountPanel', () => {
       quota: 23,
       promptTokens: 0,
       completionTokens: 0,
-      useTime: 0,
+      useTime: index === 0 ? 12 : 0,
       ip: index === 0 ? '127.0.0.1' : '',
       retryCount: index === 0 ? 2 : 0,
       requestId: `req-${index + 1}`,
@@ -162,6 +166,10 @@ describe('TuziAccountPanel', () => {
     synchronizeTuziManagedProviders.mockResolvedValue(undefined);
     discoverAndUseAllTuziProviderModels.mockResolvedValue(2);
     getModels.mockResolvedValue(['hidden-model']);
+    getProviderGroups.mockResolvedValue([
+      { group: 'default', displayName: 'default' },
+      { group: 'vip', displayName: 'VIP' },
+    ]);
     getUsageSummary.mockResolvedValue({ quota: 70, rpm: 0, tpm: 0 });
     getProfiles.mockReturnValue([
       {
@@ -212,12 +220,103 @@ describe('TuziAccountPanel', () => {
     expect(
       screen.getByRole('button', { name: '换新 default 分组 Key' })
     ).not.toBeNull();
-    expect(screen.queryByRole('button', { name: '刷新账户数据' })).toBeNull();
+    expect(screen.getByRole('button', { name: '刷新账户数据' })).not.toBeNull();
     expect(screen.queryByText('近 30 天消费')).toBeNull();
     expect(screen.queryByText('可用模型')).toBeNull();
     expect(getLogs).not.toHaveBeenCalled();
     expect(getModels).not.toHaveBeenCalled();
     expect(getUsageSummary).not.toHaveBeenCalled();
+  });
+
+  it('renders account data before a slow display-config request completes', async () => {
+    const { TuziAccountPanel } = await import('./TuziAccountPanel');
+    let resolveDisplayConfig: (config: TuziDisplayConfig) => void = () =>
+      undefined;
+    getDisplayConfig.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveDisplayConfig = resolve;
+      })
+    );
+
+    render(<TuziAccountPanel />);
+
+    expect(await screen.findByText('可用额度')).not.toBeNull();
+    expect(screen.getByText('Tuzi User')).not.toBeNull();
+    expect(screen.queryByText('正在读取账户数据')).toBeNull();
+
+    resolveDisplayConfig({
+      quotaPerUnit: 100,
+      quotaDisplayType: 'CNY',
+      usdExchangeRate: 1,
+      customCurrencySymbol: '¤',
+      customCurrencyExchangeRate: 1,
+    });
+    await waitFor(() => expect(screen.getByText('¥1459.30')).not.toBeNull());
+  });
+
+  it('filters stale local managed providers to the saved group selection', async () => {
+    getProfiles.mockReturnValue([
+      {
+        id: 'tuzi-managed-default',
+        name: 'default',
+        pricingGroup: 'default',
+        apiKey: 'sk-default',
+        enabled: true,
+      },
+      {
+        id: 'tuzi-managed-vip',
+        name: 'VIP',
+        pricingGroup: 'vip',
+        apiKey: 'sk-vip',
+        enabled: true,
+      },
+    ]);
+    window.localStorage.setItem(
+      'opentu.tuzi.provider-groups.v1',
+      JSON.stringify({ '1': ['default'] })
+    );
+    const { TuziAccountPanel } = await import('./TuziAccountPanel');
+
+    render(<TuziAccountPanel />);
+
+    await screen.findByText('可用额度');
+    expect(screen.getAllByText('default').length).toBeGreaterThan(0);
+    expect(screen.queryByText('VIP')).toBeNull();
+  });
+
+  it('force-refreshes account, managed groups, and models without loading logs', async () => {
+    const { TuziAccountPanel } = await import('./TuziAccountPanel');
+    let resolveDiscovery: (count: number) => void = () => undefined;
+    discoverAndUseAllTuziProviderModels.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveDiscovery = resolve;
+      })
+    );
+
+    render(<TuziAccountPanel />);
+    await screen.findByText('可用额度');
+
+    const refreshButton = screen.getByRole('button', { name: '刷新账户数据' });
+    fireEvent.click(refreshButton);
+
+    expect((refreshButton as HTMLButtonElement).disabled).toBe(true);
+    expect(refreshButton.querySelector('.is-spinning')).not.toBeNull();
+    expect(getLogs).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(ensureManagedProviders).toHaveBeenCalledTimes(1)
+    );
+    expect(discoverAndUseAllTuziProviderModels).toHaveBeenCalledWith(
+      expect.objectContaining({ group: 'default' })
+    );
+    expect(await screen.findByText('模型同步中')).not.toBeNull();
+    expect(screen.queryByText('正在读取账户数据')).toBeNull();
+    expect(screen.getByText('Tuzi User')).not.toBeNull();
+
+    resolveDiscovery(1);
+    await waitFor(() =>
+      expect((refreshButton as HTMLButtonElement).disabled).toBe(false)
+    );
+    expect(screen.getByText('已同步')).not.toBeNull();
   });
 
   it('asks the user to replace an invalid system token', async () => {
@@ -253,14 +352,45 @@ describe('TuziAccountPanel', () => {
     expect(screen.getByRole('button', { name: '重试' })).not.toBeNull();
   });
 
+  it('starts a fresh connection flow when the saved token is unchanged', async () => {
+    const { TuziAccountPanel } = await import('./TuziAccountPanel');
+
+    render(<TuziAccountPanel />);
+    await screen.findByText('可用额度');
+
+    const tokenInput = document.querySelector('#tuzi-system-token');
+    expect(tokenInput).not.toBeNull();
+    fireEvent.change(tokenInput as HTMLInputElement, {
+      target: { value: 'system-token' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '替换令牌' }));
+
+    expect(await screen.findByText('选择要连接的分组')).not.toBeNull();
+    expect(screen.queryByText('正在读取账户数据')).toBeNull();
+    expect(synchronizeTuziManagedProviders).not.toHaveBeenCalled();
+  });
+
   it('refreshes the visible account and managed groups after replacing the token', async () => {
     const onProvidersChanged = vi.fn();
     const { TuziAccountPanel } = await import('./TuziAccountPanel');
+    let resolveProviderSync: () => void = () => undefined;
+    let resolveDiscovery: (count: number) => void = () => undefined;
 
     render(<TuziAccountPanel onProvidersChanged={onProvidersChanged} />);
     await screen.findByText('可用额度');
 
     getAccount.mockResolvedValueOnce({
+      id: 2,
+      role: 1,
+      username: 'next-user',
+      displayName: 'Next Tuzi User',
+      email: 'next@example.com',
+      group: 'default',
+      quota: 300,
+      usedQuota: 100,
+      requestCount: 9,
+    });
+    getAccount.mockResolvedValue({
       id: 2,
       role: 1,
       username: 'next-user',
@@ -281,6 +411,18 @@ describe('TuziAccountPanel', () => {
         rotatedAt: 1700000200,
       },
     ]);
+    discoverAndUseAllTuziProviderModels.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveDiscovery = resolve;
+      })
+    );
+    synchronizeTuziManagedProviders
+      .mockResolvedValueOnce(undefined)
+      .mockReturnValueOnce(
+        new Promise<void>((resolve) => {
+          resolveProviderSync = resolve;
+        })
+      );
 
     const tokenInput = document.querySelector('#tuzi-system-token');
     expect(tokenInput).not.toBeNull();
@@ -289,14 +431,31 @@ describe('TuziAccountPanel', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: '替换令牌' }));
 
+    expect(await screen.findByText('选择要连接的分组')).not.toBeNull();
+    expect(ensureManagedProviders).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /VIP/ }));
+    fireEvent.click(screen.getByRole('button', { name: '应用分组并连接' }));
+
     expect(await screen.findByText('Next Tuzi User')).not.toBeNull();
-    expect(await screen.findByText('VIP')).not.toBeNull();
-    expect(screen.getByText('9')).not.toBeNull();
-    expect(ensureManagedProviders).toHaveBeenCalledTimes(1);
+    expect(
+      await screen.findByRole('button', { name: '换新 vip 分组 Key' })
+    ).not.toBeNull();
+    expect(await screen.findByText('9')).not.toBeNull();
+    expect(await screen.findByText('Provider 同步中')).not.toBeNull();
+    expect(screen.queryByText('正在读取账户数据')).toBeNull();
+    expect(ensureManagedProviders).toHaveBeenCalledWith(['vip']);
+
+    resolveProviderSync();
+    expect(await screen.findByText('模型同步中')).not.toBeNull();
+    expect(screen.queryByText('正在读取账户数据')).toBeNull();
     expect(synchronizeTuziManagedProviders).toHaveBeenCalledWith([
       expect.objectContaining({ id: 'tuzi-managed-vip', group: 'vip' }),
     ]);
-    expect(onProvidersChanged).toHaveBeenCalledTimes(1);
+    expect(onProvidersChanged).toHaveBeenCalledTimes(2);
+
+    resolveDiscovery(1);
+    await waitFor(() => expect(screen.getByText('已同步')).not.toBeNull());
   });
 
   it('rotates provider keys from the balance view', async () => {
@@ -325,21 +484,28 @@ describe('TuziAccountPanel', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: '日志' }));
 
+    expect(screen.queryByText('系统访问令牌')).toBeNull();
+    expect(screen.queryByRole('button', { name: '刷新账户数据' })).toBeNull();
     expect(await screen.findByText('gpt-image-1')).not.toBeNull();
     expect(screen.getByText('时间')).not.toBeNull();
     expect(screen.queryByText('渠道')).toBeNull();
     expect(screen.queryByText('用户')).toBeNull();
+    expect(screen.getByText('分组')).not.toBeNull();
     expect(screen.getByText('模型')).not.toBeNull();
-    expect(screen.getByText('输出')).not.toBeNull();
+    expect(screen.getByText('用时')).not.toBeNull();
+    expect(screen.getByText('详情')).not.toBeNull();
     expect(screen.getByText('金额')).not.toBeNull();
+    expect(screen.getByText('12 s')).not.toBeNull();
+    expect(screen.getByText('模型倍率 1')).not.toBeNull();
     expect(screen.queryByText('OpenTu')).toBeNull();
     expect(screen.queryByText('foster0214')).toBeNull();
     expect(screen.getByText('1-10 / 12')).not.toBeNull();
     expect(screen.getByText('1 / 2')).not.toBeNull();
     expect(screen.queryByText('其他详情')).toBeNull();
-    fireEvent.click(screen.getAllByText('查看详情')[0]);
+    fireEvent.click(screen.getByRole('button', { name: '展开日志 1' }));
+    expect(screen.getByRole('button', { name: '收起日志 1' })).not.toBeNull();
     expect(screen.getByText('其他详情')).not.toBeNull();
-    expect(screen.getByText('模型倍率 1')).not.toBeNull();
+    expect(screen.getAllByText('模型倍率 1')).toHaveLength(2);
     expect(screen.getByText('req-1')).not.toBeNull();
     expect(screen.getByText('Response ID')).not.toBeNull();
     expect(screen.getByText('resp-1')).not.toBeNull();

--- a/packages/drawnix/src/components/settings-dialog/TuziAccountPanel.tsx
+++ b/packages/drawnix/src/components/settings-dialog/TuziAccountPanel.tsx
@@ -9,11 +9,13 @@ import {
 } from 'react';
 import {
   AlertCircle,
+  Activity,
   ChevronDown,
   ChevronLeft,
   ChevronRight,
   KeyRound,
   Loader2,
+  RefreshCw,
   Settings2,
 } from 'lucide-react';
 import {
@@ -24,6 +26,7 @@ import {
   type TuziLogPage,
   type TuziUsageLog,
   type TuziManagedProvider,
+  type TuziProviderGroup,
 } from '../../services/tuzi-session-api';
 import { synchronizeTuziManagedProviders } from '../../services/tuzi-managed-providers';
 import { discoverAndUseAllTuziProviderModels } from '../../services/tuzi-managed-provider-models';
@@ -31,6 +34,11 @@ import { tuziEmbeddedConfig } from '../../services/tuzi-embedded-config';
 import { providerProfilesSettings } from '../../utils/settings-manager';
 import type { ProviderProfile } from '../../utils/settings-types';
 import { resetTuziSessionProviderSyncCache } from '../../services/tuzi-session-provider-sync';
+import {
+  clearTuziProviderGroupSelection,
+  getTuziProviderGroupSelection,
+  saveTuziProviderGroupSelection,
+} from '../../services/tuzi-provider-selection';
 import {
   clearTuziSystemUserId,
   clearTuziSystemToken,
@@ -81,17 +89,17 @@ interface TuziLogColumn {
   align?: 'right';
 }
 
-const LOG_COLUMN_STORAGE_KEY = 'opentu.tuziAccount.visibleLogColumns.v1';
+const LOG_COLUMN_STORAGE_KEY = 'opentu.tuziAccount.visibleLogColumns.v2';
 const LOG_COLUMNS: TuziLogColumn[] = [
-  { id: 'time', label: '时间', width: 'minmax(136px, 1.05fr)' },
-  { id: 'channel', label: '渠道', width: 'minmax(92px, 0.75fr)' },
-  { id: 'user', label: '用户', width: 'minmax(72px, 0.6fr)' },
+  { id: 'time', label: '时间', width: 'minmax(136px, 0.9fr)' },
+  { id: 'channel', label: '渠道', width: 'minmax(64px, 0.45fr)' },
+  { id: 'user', label: '用户', width: 'minmax(132px, 0.85fr)' },
   { id: 'token', label: '令牌', width: 'minmax(132px, 1fr)' },
-  { id: 'group', label: '分组', width: 'minmax(84px, 0.7fr)' },
+  { id: 'group', label: '分组', width: 'minmax(72px, 0.5fr)' },
   { id: 'type', label: '类型', width: 'minmax(64px, 0.55fr)' },
   { id: 'callStatus', label: '调用状态', width: 'minmax(92px, 0.75fr)' },
-  { id: 'model', label: '模型', width: 'minmax(140px, 1.15fr)' },
-  { id: 'useTime', label: '用时', width: 'minmax(72px, 0.6fr)' },
+  { id: 'model', label: '模型', width: 'minmax(150px, 1.05fr)' },
+  { id: 'useTime', label: '用时', width: 'minmax(72px, 0.5fr)' },
   { id: 'input', label: '输入', width: 'minmax(64px, 0.55fr)', align: 'right' },
   {
     id: 'output',
@@ -101,11 +109,11 @@ const LOG_COLUMNS: TuziLogColumn[] = [
   },
   { id: 'ip', label: 'IP', width: 'minmax(104px, 0.8fr)' },
   { id: 'retry', label: '重试', width: 'minmax(64px, 0.55fr)', align: 'right' },
-  { id: 'details', label: '详情', width: 'minmax(104px, 0.8fr)' },
+  { id: 'details', label: '详情', width: 'minmax(220px, 1.35fr)' },
   {
     id: 'amount',
     label: '金额',
-    width: 'minmax(96px, 0.75fr)',
+    width: 'minmax(82px, 0.6fr)',
     align: 'right',
   },
   { id: 'requestId', label: 'Request ID', width: 'minmax(128px, 1fr)' },
@@ -119,8 +127,9 @@ const DEFAULT_LOG_COLUMN_IDS: TuziLogColumnId[] = [
   'time',
   'channel',
   'user',
+  'group',
   'model',
-  'output',
+  'useTime',
   'details',
   'amount',
 ];
@@ -187,6 +196,13 @@ function formatLogTime(timestamp: number): string {
   }).format(new Date(timestamp * 1000));
 }
 
+function formatLogTimeParts(timestamp: number): { date: string; time: string } {
+  if (!timestamp) return { date: '-', time: '' };
+  const value = formatLogTime(timestamp);
+  const [date = value, time = ''] = value.replace(/\//g, '-').split(' ');
+  return { date, time };
+}
+
 function formatOutputTokens(log: TuziUsageLog): string {
   return formatInteger(log.completionTokens || 0);
 }
@@ -199,7 +215,22 @@ function formatLogType(log: TuziUsageLog): string {
 }
 
 function formatUseTime(log: TuziUsageLog): string {
-  return log.useTime ? `${log.useTime} ms` : '-';
+  return log.useTime ? `${log.useTime} s` : '-';
+}
+
+function logBadgeTone(value: string): number {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
+  }
+  return hash % 6;
+}
+
+function logSummary(log: TuziUsageLog): string {
+  const detail = log.other.log_detail;
+  if (typeof detail === 'string' && detail.trim()) return detail.trim();
+  if (log.content.trim()) return log.content.trim();
+  return log.callStatus || formatLogType(log);
 }
 
 function logChannelLabel(log: TuziUsageLog): string {
@@ -343,7 +374,7 @@ function buildLogDetailItems(log: TuziUsageLog): LogDetailItem[] {
   add('其他详情', log.content, true);
   add('Prompt Tokens', formatInteger(log.promptTokens || 0));
   add('Completion Tokens', formatInteger(log.completionTokens || 0));
-  add('耗时', log.useTime ? `${log.useTime} ms` : '-');
+  add('耗时', log.useTime ? `${log.useTime} s` : '-');
 
   const remainingOther = Object.fromEntries(
     Object.entries(log.other).filter(([key]) => !consumedOtherKeys.has(key))
@@ -451,7 +482,13 @@ function clearTuziDataCache(): void {
   }
 }
 
-function localManagedProviders(): TuziManagedProvider[] {
+function localManagedProviders(
+  allowedGroups?: readonly string[] | null
+): TuziManagedProvider[] {
+  const allowed =
+    allowedGroups === null || allowedGroups === undefined
+      ? null
+      : new Set(allowedGroups.map((group) => group.trim()).filter(Boolean));
   return providerProfilesSettings
     .get()
     .filter(
@@ -461,12 +498,17 @@ function localManagedProviders(): TuziManagedProvider[] {
     )
     .map((profile: ProviderProfile) => ({
       id: profile.id,
-      group: profile.pricingGroup || profile.name,
+      group: (profile.pricingGroup || profile.name).trim(),
       displayName: profile.name,
       apiKey: profile.apiKey,
       status: profile.enabled === false ? 0 : 1,
       rotatedAt: 0,
-    }));
+    }))
+    .filter(
+      (provider) =>
+        provider.group.length > 0 &&
+        (allowed === null || allowed.has(provider.group))
+    );
 }
 
 interface TuziAccountPanelProps {
@@ -477,11 +519,20 @@ export function TuziAccountPanel({
   onProvidersChanged,
 }: TuziAccountPanelProps) {
   const accountRequestVersion = useRef(0);
+  const modelsRequestVersion = useRef(0);
   const logsRequestVersion = useRef(0);
   const refreshProvidersOnNextLoad = useRef(false);
+  const initialStoredSelection = getTuziProviderGroupSelection(
+    getTuziSystemUserId()
+  );
+  const providerSelectionRequired = useRef(
+    localManagedProviders(initialStoredSelection).length === 0 &&
+      initialStoredSelection === null
+  );
   const onProvidersChangedRef = useRef(onProvidersChanged);
   const [systemToken, setSystemToken] = useState(getTuziSystemToken);
   const [systemUserId, setSystemUserId] = useState(getTuziSystemUserId);
+  const [connectionRevision, setConnectionRevision] = useState(0);
   const [tokenDraft, setTokenDraft] = useState('');
   const createClient = useCallback(
     (token = systemToken, userId = getTuziSystemUserId()) =>
@@ -490,9 +541,17 @@ export function TuziAccountPanel({
   );
   const [activeView, setActiveView] = useState<TuziAccountView>('balance');
   const [account, setAccount] = useState<TuziAccount | null>(null);
-  const [providers, setProviders] = useState<TuziManagedProvider[]>(
-    localManagedProviders
+  const [providers, setProviders] = useState<TuziManagedProvider[]>(() =>
+    localManagedProviders(initialStoredSelection)
   );
+  const [availableGroups, setAvailableGroups] = useState<TuziProviderGroup[]>(
+    []
+  );
+  const [selectedGroups, setSelectedGroups] = useState<string[]>([]);
+  const [providerSelectionPending, setProviderSelectionPending] =
+    useState(false);
+  const [providerSelectionLoading, setProviderSelectionLoading] =
+    useState(false);
   const [displayConfig, setDisplayConfig] = useState<TuziDisplayConfig>(
     DEFAULT_DISPLAY_CONFIG
   );
@@ -504,6 +563,8 @@ export function TuziAccountPanel({
   >(readVisibleLogColumns);
   const [columnSettingsOpen, setColumnSettingsOpen] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [providersLoading, setProvidersLoading] = useState(false);
+  const [modelsLoading, setModelsLoading] = useState(false);
   const [logsLoading, setLogsLoading] = useState(false);
   const [rotatingGroup, setRotatingGroup] = useState<string | null>(null);
   const [error, setError] = useState<{ code: string; message: string } | null>(
@@ -524,6 +585,10 @@ export function TuziAccountPanel({
       setError({ code: 'NOT_CONFIGURED', message: '请输入系统访问令牌' });
       return;
     }
+    const credentialsChanged =
+      nextToken !== systemToken ||
+      systemUserId.trim() !== getTuziSystemUserId();
+    clearTuziProviderGroupSelection(systemUserId);
     if (!saveTuziSystemToken(nextToken)) {
       setError({ code: 'REQUEST_FAILED', message: '系统访问令牌保存失败' });
       return;
@@ -533,16 +598,37 @@ export function TuziAccountPanel({
     logsRequestVersion.current += 1;
     refreshProvidersOnNextLoad.current = true;
     setSystemToken(nextToken);
+    setConnectionRevision((current) => current + 1);
     resetTuziSessionProviderSyncCache();
     setTokenDraft('');
-    clearTuziDataCache();
-    setAccount(null);
-    setProviders([]);
-    setDisplayConfigReady(false);
-    setLogs(EMPTY_LOG_PAGE);
+    if (credentialsChanged) {
+      clearTuziDataCache();
+      setAccount(null);
+      setProviders([]);
+      setDisplayConfigReady(false);
+      setLogs(EMPTY_LOG_PAGE);
+    }
+    setAvailableGroups([]);
+    setSelectedGroups([]);
+    setProviderSelectionPending(false);
+    setProviderSelectionLoading(false);
+    providerSelectionRequired.current = true;
     setLoading(true);
+    setProvidersLoading(false);
+    modelsRequestVersion.current += 1;
+    setModelsLoading(false);
     setError(null);
-  }, [systemUserId, tokenDraft]);
+    if (!credentialsChanged) return;
+    try {
+      await synchronizeTuziManagedProviders([]);
+      onProvidersChangedRef.current?.();
+    } catch (syncError) {
+      console.warn(
+        '[Tuzi] Failed to clear previous managed providers:',
+        syncError
+      );
+    }
+  }, [systemToken, systemUserId, tokenDraft]);
 
   const clearToken = useCallback(async () => {
     accountRequestVersion.current += 1;
@@ -556,6 +642,14 @@ export function TuziAccountPanel({
     setTokenDraft('');
     setAccount(null);
     setProviders([]);
+    setAvailableGroups([]);
+    setSelectedGroups([]);
+    setProviderSelectionPending(false);
+    setProviderSelectionLoading(false);
+    providerSelectionRequired.current = true;
+    setProvidersLoading(false);
+    modelsRequestVersion.current += 1;
+    setModelsLoading(false);
     setDisplayConfigReady(false);
     setLogs(EMPTY_LOG_PAGE);
     setError(null);
@@ -599,7 +693,13 @@ export function TuziAccountPanel({
   );
 
   const load = useCallback(
-    async (refreshProviders = false) => {
+    async (
+      refreshProviders = false,
+      discoverModels = false,
+      groups?: readonly string[],
+      prepareProviderSelection = false,
+      resetProviderSelection = false
+    ) => {
       const requestVersion = ++accountRequestVersion.current;
       const requestToken = systemToken;
       const isCurrentRequest = () =>
@@ -608,8 +708,38 @@ export function TuziAccountPanel({
       setLoading(true);
       setError(null);
       setDisplayConfigReady(false);
+      if (prepareProviderSelection) {
+        // Reveal the selection step immediately. Account and provider work is
+        // the second phase and must not hide this first, actionable screen.
+        setProviderSelectionPending(true);
+        setProviderSelectionLoading(true);
+      }
       let hasCachedAccount = false;
       try {
+        if (prepareProviderSelection) {
+          const nextGroups = await createClient().getProviderGroups();
+          if (!isCurrentRequest()) return;
+          const selectionUserId = getTuziSystemUserId();
+          const persistedSelection = resetProviderSelection
+            ? null
+            : getTuziProviderGroupSelection(selectionUserId);
+          const existingSelection = resetProviderSelection
+            ? []
+            : providerSelectionRequired.current
+            ? localManagedProviders().map((provider) => provider.group)
+            : [];
+          const allowedGroups = new Set(nextGroups.map((group) => group.group));
+          setAvailableGroups(nextGroups);
+          setSelectedGroups(
+            (persistedSelection || existingSelection).filter((group) =>
+              allowedGroups.has(group)
+            )
+          );
+          setProviderSelectionLoading(false);
+          providerSelectionRequired.current = false;
+          refreshProvidersOnNextLoad.current = false;
+          return;
+        }
         const cached = readStoredCache<{
           account: TuziAccount;
           displayConfig: TuziDisplayConfig;
@@ -619,47 +749,103 @@ export function TuziAccountPanel({
           setAccount(cached.account);
           setDisplayConfig(cached.displayConfig);
           setDisplayConfigReady(true);
-          setProviders(localManagedProviders());
-          setLoading(false);
+          const cachedSelection = getTuziProviderGroupSelection(
+            cached.account.id
+          );
+          setProviders(localManagedProviders(cachedSelection));
+          if (!refreshProviders && !prepareProviderSelection) {
+            setLoading(false);
+          }
         }
         const client = createClient();
-        const [accountResult, displayConfigResult] = await Promise.allSettled([
-          client.getAccount(),
-          client.getDisplayConfig(),
-        ]);
+        // Account data is critical for the first paint. Display configuration
+        // only affects formatting, so let it resolve in the background instead
+        // of making a slow /api/status response hold the whole panel hostage.
+        const displayConfigPromise = client
+          .getDisplayConfig()
+          .catch(() => DEFAULT_DISPLAY_CONFIG);
+        const nextAccount = await client.getAccount();
         if (!isCurrentRequest()) return;
-        if (accountResult.status === 'rejected') {
-          throw accountResult.reason;
-        }
-        const nextAccount = accountResult.value;
-        const nextDisplayConfig =
-          displayConfigResult.status === 'fulfilled'
-            ? displayConfigResult.value
-            : DEFAULT_DISPLAY_CONFIG;
+        // Publish the critical account data before optional provider/model work.
+        // This also lets the cached layout become interactive while the
+        // formatting request is still in flight.
+        setAccount(nextAccount);
+        hasCachedAccount = true;
+        setLoading(false);
         if (saveTuziSystemUserId(nextAccount.id)) {
           setSystemUserId(String(nextAccount.id));
         }
-        let nextProviders = localManagedProviders();
+        void displayConfigPromise.then((nextDisplayConfig) => {
+          if (!isCurrentRequest()) return;
+          setDisplayConfig(nextDisplayConfig);
+          setDisplayConfigReady(true);
+          writeCache(ACCOUNT_CACHE_KEY, {
+            account: nextAccount,
+            displayConfig: nextDisplayConfig,
+          });
+        });
+        const persistedGroups =
+          getTuziProviderGroupSelection(nextAccount.id) ||
+          getTuziProviderGroupSelection(getTuziSystemUserId());
+        let nextProviders = prepareProviderSelection
+          ? []
+          : localManagedProviders(persistedGroups);
         if (refreshProviders) {
+          // Account data is already usable. Provider persistence and runtime
+          // model updates are a separate phase and must not keep the central
+          // account loader visible.
+          setProvidersLoading(true);
+          await new Promise<void>((resolve) => setTimeout(resolve, 0));
+          if (!isCurrentRequest()) return;
           nextProviders = await createClient(
             requestToken,
             String(nextAccount.id)
-          ).ensureManagedProviders();
+          ).ensureManagedProviders(groups);
+          if (!isCurrentRequest()) return;
+          setProviders(nextProviders);
+          await new Promise<void>((resolve) => setTimeout(resolve, 0));
           if (!isCurrentRequest()) return;
           await synchronizeTuziManagedProviders(nextProviders);
           if (!isCurrentRequest()) return;
           onProvidersChangedRef.current?.();
+          if (discoverModels && nextProviders.length > 0) {
+            // Model discovery is intentionally non-blocking. The account and
+            // selected Keys are usable before a slow provider /models endpoint
+            // responds, and a discovery timeout must not trap the whole panel
+            // in its global loading state.
+            const modelsRequest = ++modelsRequestVersion.current;
+            setModelsLoading(true);
+            void Promise.allSettled(
+              nextProviders.map((provider) =>
+                discoverAndUseAllTuziProviderModels(provider)
+              )
+            ).then((discoveryResults) => {
+              discoveryResults.forEach((result, index) => {
+                if (result.status === 'rejected') {
+                  console.warn(
+                    `[Tuzi] Failed to synchronize models for ${nextProviders[index].group}:`,
+                    result.reason
+                  );
+                }
+              });
+              if (
+                modelsRequest === modelsRequestVersion.current &&
+                getTuziSystemToken() === requestToken
+              ) {
+                setModelsLoading(false);
+              }
+            });
+          }
         }
         setAccount(nextAccount);
-        setDisplayConfig(nextDisplayConfig);
-        setDisplayConfigReady(true);
         setProviders(nextProviders);
-        writeCache(ACCOUNT_CACHE_KEY, {
-          account: nextAccount,
-          displayConfig: nextDisplayConfig,
-        });
       } catch (loadError) {
         if (!isCurrentRequest()) return;
+        if (prepareProviderSelection) {
+          providerSelectionRequired.current = true;
+          refreshProvidersOnNextLoad.current = true;
+          setProviderSelectionLoading(false);
+        }
         if (!hasCachedAccount) {
           setAccount(null);
           setProviders([]);
@@ -667,12 +853,59 @@ export function TuziAccountPanel({
         setError(errorState(loadError));
       } finally {
         if (isCurrentRequest()) {
+          if (prepareProviderSelection) {
+            setProviderSelectionLoading(false);
+          }
+          setProvidersLoading(false);
           setLoading(false);
         }
       }
     },
     [createClient, systemToken]
   );
+
+  const handleManualRefresh = useCallback(() => {
+    if (
+      loading ||
+      providersLoading ||
+      modelsLoading ||
+      providerSelectionPending ||
+      !systemToken
+    ) {
+      return;
+    }
+    const groups = account
+      ? getTuziProviderGroupSelection(account.id) ||
+        providers.map((item) => item.group)
+      : providers.map((item) => item.group);
+    void load(true, true, groups);
+  }, [
+    account,
+    load,
+    loading,
+    modelsLoading,
+    providerSelectionPending,
+    providers,
+    providersLoading,
+    systemToken,
+  ]);
+
+  const applyProviderSelection = useCallback(() => {
+    if (loading || providerSelectionLoading) return;
+    const selectionUserId = account?.id || systemUserId;
+    if (!selectionUserId) return;
+    saveTuziProviderGroupSelection(selectionUserId, selectedGroups);
+    setProviderSelectionPending(false);
+    resetTuziSessionProviderSyncCache();
+    void load(true, true, selectedGroups);
+  }, [
+    account,
+    load,
+    loading,
+    providerSelectionLoading,
+    selectedGroups,
+    systemUserId,
+  ]);
 
   const rotateProvider = useCallback(
     async (group: string) => {
@@ -709,9 +942,15 @@ export function TuziAccountPanel({
 
   useEffect(() => {
     if (systemToken) {
-      const refreshProviders = refreshProvidersOnNextLoad.current;
-      refreshProvidersOnNextLoad.current = false;
-      void load(refreshProviders);
+      const prepareProviderSelection =
+        refreshProvidersOnNextLoad.current || providerSelectionRequired.current;
+      void load(
+        false,
+        false,
+        undefined,
+        prepareProviderSelection,
+        refreshProvidersOnNextLoad.current
+      );
     } else {
       setLoading(false);
       setAccount(null);
@@ -719,7 +958,7 @@ export function TuziAccountPanel({
       setLogs(EMPTY_LOG_PAGE);
       setDisplayConfigReady(false);
     }
-  }, [load, systemToken]);
+  }, [connectionRevision, load, systemToken]);
 
   useEffect(() => {
     if (
@@ -829,6 +1068,10 @@ export function TuziAccountPanel({
     ? '等待令牌'
     : loading
     ? '同步中'
+    : providersLoading
+    ? 'Provider 同步中'
+    : modelsLoading
+    ? '模型同步中'
     : error
     ? '同步失败'
     : '已同步';
@@ -860,106 +1103,204 @@ export function TuziAccountPanel({
         </aside>
 
         <main className="tuzi-account-panel__main">
-          <header className="tuzi-account-panel__account">
-            <div>
-              <h2>Tuzi 账户</h2>
-              <p>{account?.displayName || account?.username || '当前账户'}</p>
-            </div>
-            <div
-              className="tuzi-account-panel__status-list"
-              aria-label="账户状态"
-            >
-              <span
-                className={
-                  error
-                    ? 'tuzi-account-panel__status tuzi-account-panel__status--danger'
-                    : 'tuzi-account-panel__status tuzi-account-panel__status--ok'
-                }
-              >
-                {loginStatusText}
-              </span>
-              <span
-                className={
-                  loading
-                    ? 'tuzi-account-panel__status tuzi-account-panel__status--pending'
-                    : error
-                    ? 'tuzi-account-panel__status tuzi-account-panel__status--danger'
-                    : 'tuzi-account-panel__status'
-                }
-              >
-                {syncStatusText}
-              </span>
-            </div>
-          </header>
-
-          <div className="tuzi-account-panel__content">
-            <section
-              className="tuzi-account-panel__token"
-              aria-labelledby="tuzi-system-token-title"
-            >
-              <div className="tuzi-account-panel__token-heading">
-                <div>
-                  <h3 id="tuzi-system-token-title">
-                    <KeyRound size={16} aria-hidden="true" />
-                    系统访问令牌
-                  </h3>
-                  <p>
-                    使用系统令牌读取账户数据并同步托管 Provider。
-                    <a
-                      href="https://api.tu-zi.com/console/personal"
-                      target="_blank"
-                      rel="noreferrer"
-                      className="tuzi-account-panel__token-link"
-                    >
-                      前往个人设置复制令牌
-                    </a>
-                  </p>
-                </div>
+          {activeView === 'balance' || providerSelectionPending ? (
+            <header className="tuzi-account-panel__account">
+              <div>
+                <h2>Tuzi 账户</h2>
+                <p>{account?.displayName || account?.username || '当前账户'}</p>
               </div>
-              <div className="tuzi-account-panel__token-actions">
-                <input
-                  id="tuzi-system-user-id"
-                  type="text"
-                  inputMode="numeric"
-                  value={systemUserId}
-                  onChange={(event) =>
-                    setSystemUserId(event.target.value.replace(/\D/g, ''))
+              <div
+                className="tuzi-account-panel__status-list"
+                aria-label="账户状态"
+              >
+                <span
+                  className={
+                    error
+                      ? 'tuzi-account-panel__status tuzi-account-panel__status--danger'
+                      : 'tuzi-account-panel__status tuzi-account-panel__status--ok'
                   }
-                  onBlur={() => saveTuziSystemUserId(systemUserId)}
-                  placeholder="用户 ID"
-                  aria-label="Tuzi 用户 ID"
-                  autoComplete="off"
-                />
-                <input
-                  id="tuzi-system-token"
-                  type="password"
-                  value={tokenDraft}
-                  onChange={(event) => setTokenDraft(event.target.value)}
-                  onKeyDown={(event) => {
-                    if (event.key === 'Enter') void saveToken();
-                  }}
-                  placeholder={
-                    systemToken
-                      ? maskTuziSystemToken(systemToken)
-                      : '粘贴系统访问令牌'
+                >
+                  {loginStatusText}
+                </span>
+                <span
+                  className={
+                    loading || providersLoading || modelsLoading
+                      ? 'tuzi-account-panel__status tuzi-account-panel__status--pending'
+                      : error
+                      ? 'tuzi-account-panel__status tuzi-account-panel__status--danger'
+                      : 'tuzi-account-panel__status'
                   }
-                  aria-label="系统访问令牌"
-                  autoComplete="off"
-                />
-                <button type="button" onClick={() => void saveToken()}>
-                  {systemToken ? '替换令牌' : '连接'}
-                </button>
-                {systemToken ? (
+                >
+                  {syncStatusText}
+                </span>
+                <HoverTip content="刷新账户、分组和模型" showArrow={false}>
                   <button
                     type="button"
-                    className="is-subtle"
-                    onClick={() => void clearToken()}
+                    className="tuzi-account-panel__refresh"
+                    aria-label="刷新账户数据"
+                    disabled={
+                      loading ||
+                      providersLoading ||
+                      modelsLoading ||
+                      providerSelectionPending ||
+                      !systemToken
+                    }
+                    onClick={handleManualRefresh}
                   >
-                    清除
+                    <RefreshCw
+                      size={16}
+                      className={
+                        loading || providersLoading || modelsLoading
+                          ? 'is-spinning'
+                          : undefined
+                      }
+                      aria-hidden="true"
+                    />
                   </button>
-                ) : null}
+                </HoverTip>
               </div>
-            </section>
+            </header>
+          ) : null}
+
+          <div className="tuzi-account-panel__content">
+            {activeView === 'balance' || providerSelectionPending ? (
+              <section
+                className="tuzi-account-panel__token"
+                aria-labelledby="tuzi-system-token-title"
+              >
+                <div className="tuzi-account-panel__token-heading">
+                  <div>
+                    <h3 id="tuzi-system-token-title">
+                      <KeyRound size={16} aria-hidden="true" />
+                      系统访问令牌
+                    </h3>
+                    <p>
+                      使用系统令牌读取账户数据并同步托管 Provider。
+                      <a
+                        href="https://api.tu-zi.com/console/personal"
+                        target="_blank"
+                        rel="noreferrer"
+                        className="tuzi-account-panel__token-link"
+                      >
+                        前往个人设置复制令牌
+                      </a>
+                    </p>
+                  </div>
+                </div>
+                <div className="tuzi-account-panel__token-actions">
+                  <input
+                    id="tuzi-system-user-id"
+                    type="text"
+                    inputMode="numeric"
+                    value={systemUserId}
+                    onChange={(event) =>
+                      setSystemUserId(event.target.value.replace(/\D/g, ''))
+                    }
+                    onBlur={() => saveTuziSystemUserId(systemUserId)}
+                    placeholder="用户 ID"
+                    aria-label="Tuzi 用户 ID"
+                    autoComplete="off"
+                  />
+                  <input
+                    id="tuzi-system-token"
+                    type="password"
+                    value={tokenDraft}
+                    onChange={(event) => setTokenDraft(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') void saveToken();
+                    }}
+                    placeholder={
+                      systemToken
+                        ? maskTuziSystemToken(systemToken)
+                        : '粘贴系统访问令牌'
+                    }
+                    aria-label="系统访问令牌"
+                    autoComplete="off"
+                  />
+                  <button type="button" onClick={() => void saveToken()}>
+                    {systemToken ? '替换令牌' : '连接'}
+                  </button>
+                  {systemToken ? (
+                    <button
+                      type="button"
+                      className="is-subtle"
+                      onClick={() => void clearToken()}
+                    >
+                      清除
+                    </button>
+                  ) : null}
+                </div>
+              </section>
+            ) : null}
+            {providerSelectionPending ? (
+              <section
+                className="tuzi-account-panel__provider-selection"
+                aria-labelledby="tuzi-provider-selection-title"
+              >
+                <div className="tuzi-account-panel__section-heading">
+                  <div>
+                    <h3 id="tuzi-provider-selection-title">选择要连接的分组</h3>
+                    <span>
+                      未勾选的分组不会创建 API Key，也不会出现在供应商中。
+                    </span>
+                  </div>
+                  <span>{selectedGroups.length} 个已选</span>
+                </div>
+                {providerSelectionLoading ? (
+                  <div className="tuzi-account-panel__loading">
+                    <Loader2 size={18} className="is-spinning" />
+                    <span>正在读取可用分组</span>
+                  </div>
+                ) : availableGroups.length ? (
+                  <div className="tuzi-account-panel__provider-options">
+                    {availableGroups.map((group) => (
+                      <label
+                        key={group.group}
+                        className={
+                          selectedGroups.includes(group.group)
+                            ? 'is-selected'
+                            : undefined
+                        }
+                      >
+                        <input
+                          type="checkbox"
+                          checked={selectedGroups.includes(group.group)}
+                          onChange={() =>
+                            setSelectedGroups((current) =>
+                              current.includes(group.group)
+                                ? current.filter((item) => item !== group.group)
+                                : [...current, group.group]
+                            )
+                          }
+                        />
+                        <span>
+                          <strong>{group.displayName}</strong>
+                          <small>{group.group}</small>
+                        </span>
+                      </label>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="tuzi-account-panel__empty">暂无可用分组</div>
+                )}
+                <div className="tuzi-account-panel__provider-selection-actions">
+                  <button
+                    type="button"
+                    disabled={
+                      loading ||
+                      providerSelectionLoading ||
+                      (!account && !systemUserId)
+                    }
+                    onClick={applyProviderSelection}
+                  >
+                    {loading ? (
+                      <Loader2 size={16} className="is-spinning" />
+                    ) : null}
+                    应用分组并连接
+                  </button>
+                </div>
+              </section>
+            ) : null}
             {error ? (
               <div className="tuzi-account-panel__error" role="alert">
                 <AlertCircle size={20} />
@@ -978,14 +1319,36 @@ export function TuziAccountPanel({
                 <button
                   type="button"
                   disabled={loading || !systemToken}
-                  onClick={() => void load(true)}
+                  onClick={() =>
+                    providerSelectionRequired.current ||
+                    refreshProvidersOnNextLoad.current
+                      ? void load(
+                          false,
+                          false,
+                          undefined,
+                          true,
+                          refreshProvidersOnNextLoad.current
+                        )
+                      : void load(
+                          true,
+                          false,
+                          account
+                            ? getTuziProviderGroupSelection(account.id) ||
+                                providers.map((provider) => provider.group)
+                            : systemUserId
+                            ? getTuziProviderGroupSelection(systemUserId) ||
+                              providers.map((provider) => provider.group)
+                            : providers.map((provider) => provider.group)
+                        )
+                  }
                 >
                   重试
                 </button>
               </div>
             ) : null}
 
-            {!systemToken || (!loading && (!account || error)) ? (
+            {providerSelectionPending ? null : !systemToken ||
+              (!loading && (!account || error)) ? (
               <div className="tuzi-account-panel__not-configured">
                 <KeyRound size={24} aria-hidden="true" />
                 <strong>
@@ -1195,6 +1558,11 @@ export function TuziAccountPanel({
                           <button
                             type="button"
                             className="tuzi-account-panel__log-row"
+                            aria-label={
+                              (expandedLogId === log.id ? '收起' : '展开') +
+                              '日志 ' +
+                              log.id
+                            }
                             aria-expanded={expandedLogId === log.id}
                             style={logGridStyle}
                             onClick={() =>
@@ -1204,29 +1572,122 @@ export function TuziAccountPanel({
                             }
                           >
                             {visibleLogColumns.map((column) => {
+                              const expanded = expandedLogId === log.id;
                               if (column.id === 'time') {
+                                const timeParts = formatLogTimeParts(
+                                  log.createdAt
+                                );
                                 return (
-                                  <time key={column.id}>
-                                    {formatLogTime(log.createdAt)}
+                                  <time
+                                    key={column.id}
+                                    className="tuzi-account-panel__log-time"
+                                  >
+                                    <ChevronRight
+                                      size={15}
+                                      aria-hidden="true"
+                                      className={
+                                        expanded ? 'is-expanded' : undefined
+                                      }
+                                    />
+                                    <span>
+                                      <strong>{timeParts.date}</strong>
+                                      <small>{timeParts.time}</small>
+                                    </span>
                                   </time>
                                 );
                               }
-                              if (column.id === 'model') {
+                              if (column.id === 'channel') {
+                                const channel = logChannelLabel(log);
                                 return (
-                                  <strong key={column.id}>
-                                    {log.modelName || '系统记录'}
-                                  </strong>
+                                  <span
+                                    key={column.id}
+                                    className="tuzi-account-panel__log-badge"
+                                    data-tone={logBadgeTone(channel)}
+                                    title={channel}
+                                  >
+                                    {channel}
+                                  </span>
+                                );
+                              }
+                              if (column.id === 'user') {
+                                const user = logUserLabel(log, account);
+                                return (
+                                  <span
+                                    key={column.id}
+                                    className="tuzi-account-panel__log-user"
+                                    title={user}
+                                  >
+                                    <span
+                                      className="tuzi-account-panel__log-user-avatar"
+                                      data-tone={logBadgeTone(user)}
+                                      aria-hidden="true"
+                                    >
+                                      {user === '-'
+                                        ? '?'
+                                        : user.charAt(0).toUpperCase()}
+                                    </span>
+                                    <span>{user}</span>
+                                  </span>
+                                );
+                              }
+                              if (
+                                column.id === 'token' ||
+                                column.id === 'group'
+                              ) {
+                                const value =
+                                  column.id === 'token'
+                                    ? logTokenLabel(log)
+                                    : logGroupLabel(log);
+                                return (
+                                  <span
+                                    key={column.id}
+                                    className="tuzi-account-panel__log-badge tuzi-account-panel__log-badge--muted"
+                                    data-tone={logBadgeTone(value)}
+                                    title={value}
+                                  >
+                                    {value}
+                                  </span>
+                                );
+                              }
+                              if (column.id === 'model') {
+                                const model = log.modelName || '系统记录';
+                                return (
+                                  <span
+                                    key={column.id}
+                                    className="tuzi-account-panel__log-model"
+                                    title={model}
+                                  >
+                                    <Activity size={14} aria-hidden="true" />
+                                    <strong>{model}</strong>
+                                  </span>
+                                );
+                              }
+                              if (column.id === 'useTime') {
+                                const duration = log.useTime || 0;
+                                return (
+                                  <span
+                                    key={column.id}
+                                    className="tuzi-account-panel__log-duration"
+                                    data-tone={
+                                      duration < 101
+                                        ? 'fast'
+                                        : duration < 300
+                                        ? 'medium'
+                                        : 'slow'
+                                    }
+                                  >
+                                    {formatUseTime(log)}
+                                  </span>
                                 );
                               }
                               if (column.id === 'details') {
                                 return (
                                   <span
                                     key={column.id}
-                                    className="tuzi-account-panel__log-detail-preview"
+                                    className="tuzi-account-panel__log-summary"
+                                    title={logSummary(log)}
                                   >
-                                    {expandedLogId === log.id
-                                      ? '收起详情'
-                                      : '查看详情'}
+                                    {logSummary(log)}
                                   </span>
                                 );
                               }
@@ -1244,20 +1705,10 @@ export function TuziAccountPanel({
                               }
 
                               const value =
-                                column.id === 'channel'
-                                  ? logChannelLabel(log)
-                                  : column.id === 'user'
-                                  ? logUserLabel(log, account)
-                                  : column.id === 'token'
-                                  ? logTokenLabel(log)
-                                  : column.id === 'group'
-                                  ? logGroupLabel(log)
-                                  : column.id === 'type'
+                                column.id === 'type'
                                   ? formatLogType(log)
                                   : column.id === 'callStatus'
                                   ? log.callStatus || '-'
-                                  : column.id === 'useTime'
-                                  ? formatUseTime(log)
                                   : column.id === 'input'
                                   ? formatInteger(log.promptTokens || 0)
                                   : column.id === 'output'

--- a/packages/drawnix/src/components/settings-dialog/TuziAccountPanel.tsx
+++ b/packages/drawnix/src/components/settings-dialog/TuziAccountPanel.tsx
@@ -552,6 +552,7 @@ export function TuziAccountPanel({
     useState(false);
   const [providerSelectionLoading, setProviderSelectionLoading] =
     useState(false);
+  const [providerSelectionFailed, setProviderSelectionFailed] = useState(false);
   const [displayConfig, setDisplayConfig] = useState<TuziDisplayConfig>(
     DEFAULT_DISPLAY_CONFIG
   );
@@ -612,6 +613,7 @@ export function TuziAccountPanel({
     setSelectedGroups([]);
     setProviderSelectionPending(false);
     setProviderSelectionLoading(false);
+    setProviderSelectionFailed(false);
     providerSelectionRequired.current = true;
     setLoading(true);
     setProvidersLoading(false);
@@ -646,6 +648,7 @@ export function TuziAccountPanel({
     setSelectedGroups([]);
     setProviderSelectionPending(false);
     setProviderSelectionLoading(false);
+    setProviderSelectionFailed(false);
     providerSelectionRequired.current = true;
     setProvidersLoading(false);
     modelsRequestVersion.current += 1;
@@ -713,6 +716,7 @@ export function TuziAccountPanel({
         // the second phase and must not hide this first, actionable screen.
         setProviderSelectionPending(true);
         setProviderSelectionLoading(true);
+        setProviderSelectionFailed(false);
       }
       let hasCachedAccount = false;
       try {
@@ -736,6 +740,7 @@ export function TuziAccountPanel({
             )
           );
           setProviderSelectionLoading(false);
+          setProviderSelectionFailed(false);
           providerSelectionRequired.current = false;
           refreshProvidersOnNextLoad.current = false;
           return;
@@ -845,6 +850,7 @@ export function TuziAccountPanel({
           providerSelectionRequired.current = true;
           refreshProvidersOnNextLoad.current = true;
           setProviderSelectionLoading(false);
+          setProviderSelectionFailed(true);
         }
         if (!hasCachedAccount) {
           setAccount(null);
@@ -891,7 +897,7 @@ export function TuziAccountPanel({
   ]);
 
   const applyProviderSelection = useCallback(() => {
-    if (loading || providerSelectionLoading) return;
+    if (loading || providerSelectionLoading || providerSelectionFailed) return;
     const selectionUserId = account?.id || systemUserId;
     if (!selectionUserId) return;
     saveTuziProviderGroupSelection(selectionUserId, selectedGroups);
@@ -902,6 +908,7 @@ export function TuziAccountPanel({
     account,
     load,
     loading,
+    providerSelectionFailed,
     providerSelectionLoading,
     selectedGroups,
     systemUserId,
@@ -1251,7 +1258,7 @@ export function TuziAccountPanel({
                     <Loader2 size={18} className="is-spinning" />
                     <span>正在读取可用分组</span>
                   </div>
-                ) : availableGroups.length ? (
+                ) : providerSelectionFailed ? null : availableGroups.length ? (
                   <div className="tuzi-account-panel__provider-options">
                     {availableGroups.map((group) => (
                       <label
@@ -1289,6 +1296,7 @@ export function TuziAccountPanel({
                     disabled={
                       loading ||
                       providerSelectionLoading ||
+                      providerSelectionFailed ||
                       (!account && !systemUserId)
                     }
                     onClick={applyProviderSelection}

--- a/packages/drawnix/src/components/settings-dialog/tuzi-account-panel.scss
+++ b/packages/drawnix/src/components/settings-dialog/tuzi-account-panel.scss
@@ -108,6 +108,38 @@
     }
   }
 
+  &__refresh {
+    width: 30px;
+    height: 30px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: 1px solid var(--tuzi-panel-border);
+    border-radius: 6px;
+    color: #344054;
+    background: #fff;
+    cursor: pointer;
+    transition: background-color 0.14s ease, border-color 0.14s ease,
+      color 0.14s ease;
+
+    &:hover:not(:disabled) {
+      border-color: #cfd7e2;
+      background: #f8fafc;
+    }
+
+    &:disabled {
+      color: #a7b0be;
+      cursor: not-allowed;
+      background: #f8fafc;
+    }
+
+    &:focus-visible {
+      outline: 2px solid #84b6ff;
+      outline-offset: 1px;
+    }
+  }
+
   &__body {
     min-height: 0;
     flex: 1 1 auto;
@@ -419,6 +451,102 @@
     border-top: 1px solid var(--tuzi-panel-border);
   }
 
+  &__provider-selection {
+    margin-top: 18px;
+    padding: 16px;
+    border: 1px solid #c7d7fe;
+    border-radius: 8px;
+    background: #f7f9ff;
+
+    .tuzi-account-panel__section-heading {
+      align-items: flex-start;
+
+      h3 {
+        margin-bottom: 4px;
+      }
+
+      span {
+        display: block;
+      }
+    }
+  }
+
+  &__provider-options {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+    gap: 8px;
+
+    label {
+      min-width: 0;
+      display: flex;
+      align-items: flex-start;
+      gap: 9px;
+      padding: 10px;
+      border: 1px solid var(--tuzi-panel-border);
+      border-radius: 6px;
+      background: #fff;
+      cursor: pointer;
+
+      input {
+        margin: 2px 0 0;
+      }
+
+      span {
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+      }
+
+      strong {
+        overflow: hidden;
+        color: #111827;
+        font-size: 13px;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      small {
+        overflow: hidden;
+        color: var(--tuzi-panel-muted);
+        font-size: 11px;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      &.is-selected {
+        border-color: #f3b34c;
+        background: #fffaf0;
+      }
+    }
+  }
+
+  &__provider-selection-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 12px;
+
+    button {
+      min-height: 34px;
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+      padding: 7px 12px;
+      border: 1px solid #3478e5;
+      border-radius: 6px;
+      color: #fff;
+      background: #3478e5;
+      font-size: 12px;
+      font-weight: 700;
+      cursor: pointer;
+
+      &:disabled {
+        cursor: not-allowed;
+        opacity: 0.6;
+      }
+    }
+  }
+
   &__section--logs {
     margin-top: 0;
     padding-top: 0;
@@ -641,7 +769,7 @@
     display: grid;
     grid-template-columns: var(--tuzi-log-columns);
     align-items: center;
-    gap: 14px;
+    gap: 10px;
   }
 
   &__log-head {
@@ -650,7 +778,7 @@
     z-index: 1;
     width: max(920px, 100%);
     min-height: 42px;
-    padding: 0 14px;
+    padding: 0 26px 0 14px;
     border-bottom: 1px solid var(--tuzi-panel-border);
     background: #f8fafc;
     color: var(--tuzi-panel-muted);
@@ -668,8 +796,8 @@
 
   &__log-row {
     width: 100%;
-    min-height: 56px;
-    padding: 10px 14px;
+    min-height: 60px;
+    padding: 10px 26px 10px 14px;
     border: 0;
     background: #fff;
     color: inherit;
@@ -677,44 +805,15 @@
     cursor: pointer;
     transition: background-color 0.14s ease;
 
-    time,
-    span {
-      color: #52627a;
-      font-size: 12.5px;
-    }
-
-    > div {
-      min-width: 0;
-      display: flex;
-      flex-direction: column;
-      gap: 3px;
-
-      strong,
-      span {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
-
-      strong {
-        font-size: 13px;
-      }
-    }
-
-    > time,
-    > span,
-    > strong {
-      color: #111827;
-      font-size: 15px;
-      font-weight: 700;
-      letter-spacing: 0;
-    }
-
     > time,
     > span,
     > strong {
       min-width: 0;
       overflow: hidden;
+      color: #344054;
+      font-size: 12.5px;
+      font-weight: 500;
+      letter-spacing: 0;
       text-overflow: ellipsis;
       white-space: nowrap;
     }
@@ -722,6 +821,14 @@
     > span,
     > time {
       font-variant-numeric: tabular-nums;
+    }
+
+    > .tuzi-account-panel__log-summary {
+      display: -webkit-box;
+      overflow: hidden;
+      white-space: normal;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
     }
 
     &:hover {
@@ -738,12 +845,207 @@
     }
   }
 
-  &__log-detail-preview {
-    color: #315f9f;
+  &__log-time {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+
+    > svg {
+      flex: 0 0 auto;
+      color: #98a2b3;
+      transition: transform 0.15s ease;
+
+      &.is-expanded {
+        transform: rotate(90deg);
+      }
+    }
+
+    > span {
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 1px;
+    }
+
+    strong,
+    small {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    strong {
+      color: #344054;
+      font-size: 12.5px;
+      font-weight: 600;
+    }
+
+    small {
+      color: #98a2b3;
+      font-size: 11px;
+      font-weight: 500;
+    }
+  }
+
+  &__log-badge {
+    max-width: 100%;
+    width: max-content;
+    min-height: 24px;
+    display: inline-flex;
+    align-items: center;
+    justify-self: start;
+    padding: 3px 8px;
+    border: 1px solid transparent;
+    border-radius: 999px;
+    overflow: hidden;
+    font-size: 11.5px;
     font-weight: 650;
+    line-height: 1;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    &[data-tone='0'] {
+      border-color: #bfd7ff;
+      color: #175cd3;
+      background: #eff6ff;
+    }
+
+    &[data-tone='1'] {
+      border-color: #a6f4c5;
+      color: #067647;
+      background: #ecfdf3;
+    }
+
+    &[data-tone='2'] {
+      border-color: #fedf89;
+      color: #b54708;
+      background: #fffaeb;
+    }
+
+    &[data-tone='3'] {
+      border-color: #d9d6fe;
+      color: #5925dc;
+      background: #f4f3ff;
+    }
+
+    &[data-tone='4'] {
+      border-color: #fecdc9;
+      color: #b42318;
+      background: #fef3f2;
+    }
+
+    &[data-tone='5'] {
+      border-color: #a5f0fc;
+      color: #0e7090;
+      background: #ecfdff;
+    }
+  }
+
+  &__log-badge--muted {
+    border-color: #d0d5dd;
+    color: #475467;
+    background: #f9fafb;
+  }
+
+  &__log-user {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+
+    > span:last-child {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+
+  &__log-user-avatar {
+    width: 26px;
+    height: 26px;
+    flex: 0 0 26px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    color: #fff;
+    background: #475467;
+    font-size: 11px;
+    font-weight: 750;
+
+    &[data-tone='0'] {
+      background: #2e90fa;
+    }
+
+    &[data-tone='1'] {
+      background: #12b76a;
+    }
+
+    &[data-tone='2'] {
+      background: #f79009;
+    }
+
+    &[data-tone='3'] {
+      background: #7f56d9;
+    }
+
+    &[data-tone='4'] {
+      background: #f04438;
+    }
+
+    &[data-tone='5'] {
+      background: #06aed4;
+    }
+  }
+
+  &__log-model {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+
+    svg {
+      flex: 0 0 auto;
+      color: #667085;
+    }
+
+    strong {
+      min-width: 0;
+      overflow: hidden;
+      color: #1d2939;
+      font-size: 12.5px;
+      font-weight: 650;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+
+  &__log-duration {
+    font-weight: 650;
+
+    &[data-tone='fast'] {
+      color: #067647;
+    }
+
+    &[data-tone='medium'] {
+      color: #b54708;
+    }
+
+    &[data-tone='slow'] {
+      color: #b42318;
+    }
+  }
+
+  &__log-summary {
+    color: #475467;
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1.45;
   }
 
   &__log-quota {
+    color: #101828;
+    font-size: 12.5px;
+    font-weight: 700;
     text-align: right;
     font-variant-numeric: tabular-nums;
   }

--- a/packages/drawnix/src/components/startup/DrawnixDeferredRuntime.tsx
+++ b/packages/drawnix/src/components/startup/DrawnixDeferredRuntime.tsx
@@ -57,13 +57,9 @@ export function DrawnixDeferredRuntime({
       return;
     }
 
-    const timer = window.setTimeout(() => {
+    return runWhenIdle(() => {
       modelPricingService.warmupProfiles(providerProfiles);
-    }, 0);
-
-    return () => {
-      window.clearTimeout(timer);
-    };
+    }, 5_000);
   }, [providerProfiles]);
 
   useEffect(() => {

--- a/packages/drawnix/src/services/__tests__/tuzi-managed-provider-models.test.ts
+++ b/packages/drawnix/src/services/__tests__/tuzi-managed-provider-models.test.ts
@@ -37,17 +37,18 @@ describe('Tuzi managed provider model synchronization', () => {
   });
 
   it('discovers and enables every model returned for the group key', async () => {
-    await expect(discoverAndUseAllTuziProviderModels(provider)).resolves.toBe(2);
+    await expect(discoverAndUseAllTuziProviderModels(provider)).resolves.toBe(
+      2
+    );
 
     expect(discover).toHaveBeenCalledWith(
       provider.id,
       'http://localhost:3100/v1',
-      'sk-new'
+      'sk-new',
+      [],
+      { selectAll: true }
     );
-    expect(applySelection).toHaveBeenCalledWith(provider.id, [
-      'model-a',
-      'model-b',
-    ]);
+    expect(applySelection).not.toHaveBeenCalled();
   });
 
   it('only refreshes models for first-time or changed keys', async () => {
@@ -63,7 +64,9 @@ describe('Tuzi managed provider model synchronization', () => {
     expect(discover).toHaveBeenCalledWith(
       provider.id,
       expect.any(String),
-      provider.apiKey
+      provider.apiKey,
+      [],
+      { selectAll: true }
     );
   });
 

--- a/packages/drawnix/src/services/__tests__/tuzi-managed-providers.test.ts
+++ b/packages/drawnix/src/services/__tests__/tuzi-managed-providers.test.ts
@@ -145,4 +145,28 @@ describe('synchronizeTuziManagedProviders', () => {
       { profileId: 'custom-provider' },
     ]);
   });
+
+  it('does not broadcast settings when managed providers are unchanged', async () => {
+    const provider = {
+      id: 'tuzi-managed-image',
+      group: 'image',
+      displayName: '图片分组',
+      apiKey: 'sk-new-image',
+      status: 1,
+      rotatedAt: 1700000000,
+    };
+
+    await synchronizeTuziManagedProviders([provider]);
+    const updatedProfiles = update.mock.calls[0][0];
+    const updatedCatalogs = catalogUpdate.mock.calls[0][0];
+    update.mockClear();
+    catalogUpdate.mockClear();
+    get.mockReturnValue(updatedProfiles);
+    catalogGet.mockReturnValue(updatedCatalogs);
+
+    await synchronizeTuziManagedProviders([provider]);
+
+    expect(update).not.toHaveBeenCalled();
+    expect(catalogUpdate).not.toHaveBeenCalled();
+  });
 });

--- a/packages/drawnix/src/services/__tests__/tuzi-session-api.test.ts
+++ b/packages/drawnix/src/services/__tests__/tuzi-session-api.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+// @vitest-environment-options {"url":"http://localhost:3100"}
 import { describe, expect, it, vi } from 'vitest';
 import { readTuziEmbeddedConfig } from '../tuzi-embedded-config';
 import { TuziSessionApiClient, TuziSessionApiError } from '../tuzi-session-api';
@@ -215,6 +217,92 @@ describe('TuziSessionApiClient', () => {
           'New-Api-User': '40832',
         }),
       })
+    );
+  });
+
+  it('limits managed provider creation to the selected groups', async () => {
+    const fetcher = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ success: true, data: { providers: [] } }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+    );
+    const client = new TuziSessionApiClient(config, fetcher as typeof fetch);
+
+    await client.ensureManagedProviders(['vip', 'vip']);
+
+    expect(fetcher).toHaveBeenCalledWith(
+      'http://localhost:3100/api/opentu/providers/ensure',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ groups: ['vip'] }),
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+        }),
+      })
+    );
+  });
+
+  it('filters legacy all-group responses to the requested allowlist', async () => {
+    const fetcher = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              providers: [
+                {
+                  id: 'tuzi-managed-default',
+                  group: 'default',
+                  display_name: 'default',
+                  api_key: 'sk-default',
+                  status: 1,
+                },
+                {
+                  id: 'tuzi-managed-vip',
+                  group: 'vip',
+                  display_name: 'VIP',
+                  api_key: 'sk-vip',
+                  status: 1,
+                },
+              ],
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+    );
+    const client = new TuziSessionApiClient(config, fetcher as typeof fetch);
+
+    await expect(client.ensureManagedProviders(['default'])).resolves.toEqual([
+      expect.objectContaining({ group: 'default' }),
+    ]);
+    await expect(client.ensureManagedProviders([])).resolves.toEqual([]);
+  });
+
+  it('reads authorized provider groups without creating managed keys', async () => {
+    const fetcher = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: [
+              { group: 'default', display_name: '默认分组' },
+              { group: 'vip', display_name: 'VIP 分组' },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+    );
+    const client = new TuziSessionApiClient(config, fetcher as typeof fetch);
+
+    await expect(client.getProviderGroups()).resolves.toEqual([
+      { group: 'default', displayName: '默认分组' },
+      { group: 'vip', displayName: 'VIP 分组' },
+    ]);
+    expect(fetcher).toHaveBeenCalledWith(
+      'http://localhost:3100/api/opentu/provider-groups',
+      expect.objectContaining({ method: 'GET' })
     );
   });
 

--- a/packages/drawnix/src/services/__tests__/tuzi-session-api.test.ts
+++ b/packages/drawnix/src/services/__tests__/tuzi-session-api.test.ts
@@ -306,6 +306,60 @@ describe('TuziSessionApiClient', () => {
     );
   });
 
+  it('retries one transient provider-group read failure', async () => {
+    const fetcher = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: [{ group: 'default', display_name: '默认分组' }],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      );
+    const client = new TuziSessionApiClient(config, fetcher as typeof fetch);
+
+    await expect(client.getProviderGroups()).resolves.toEqual([
+      { group: 'default', displayName: '默认分组' },
+    ]);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry a rejected provider-group authorization', async () => {
+    const fetcher = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            success: false,
+            error: { code: 'TOKEN_INVALID', message: '令牌无效' },
+          }),
+          { status: 401, headers: { 'Content-Type': 'application/json' } }
+        )
+    );
+    const client = new TuziSessionApiClient(config, fetcher as typeof fetch);
+
+    await expect(client.getProviderGroups()).rejects.toMatchObject({
+      code: 'TOKEN_INVALID',
+      status: 401,
+    });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops after one retry when provider-group reads keep failing', async () => {
+    const fetcher = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'));
+    const client = new TuziSessionApiClient(config, fetcher as typeof fetch);
+
+    await expect(client.getProviderGroups()).rejects.toMatchObject({
+      code: 'REQUEST_FAILED',
+    });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
   it('rotates managed providers with an explicit old-token delete action', async () => {
     const fetcher = vi.fn(
       async () =>

--- a/packages/drawnix/src/services/__tests__/tuzi-session-provider-sync.test.ts
+++ b/packages/drawnix/src/services/__tests__/tuzi-session-provider-sync.test.ts
@@ -9,11 +9,13 @@ const {
   synchronizeTuziManagedProviders,
   discoverChangedTuziProviderModels,
   getProfiles,
+  getSystemUserId,
 } = vi.hoisted(() => ({
   ensureManagedProviders: vi.fn(),
   synchronizeTuziManagedProviders: vi.fn(),
   discoverChangedTuziProviderModels: vi.fn(),
   getProfiles: vi.fn(),
+  getSystemUserId: vi.fn(),
 }));
 
 vi.mock('../tuzi-embedded-config', () => ({
@@ -21,6 +23,7 @@ vi.mock('../tuzi-embedded-config', () => ({
 }));
 vi.mock('../tuzi-token-auth', () => ({
   hasTuziSystemToken: () => true,
+  getTuziSystemUserId: getSystemUserId,
 }));
 vi.mock('../tuzi-session-api', () => ({
   TuziSessionApiError: class TuziSessionApiError extends Error {
@@ -44,24 +47,35 @@ describe('syncTuziSessionProviders', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetTuziSessionProviderSyncCache();
+    getSystemUserId.mockReturnValue('1');
     getProfiles.mockReturnValue([]);
     synchronizeTuziManagedProviders.mockResolvedValue(undefined);
     discoverChangedTuziProviderModels.mockResolvedValue(undefined);
   });
 
-  it('ensures every authorized group and replaces local managed providers', async () => {
+  it('keeps legacy managed group selection when no saved choice exists', async () => {
     const providers = [
       { id: 'tuzi-managed-default', group: 'default', apiKey: 'sk-default' },
       { id: 'tuzi-managed-vip', group: 'vip', apiKey: 'sk-vip' },
     ];
+    getProfiles.mockReturnValue(
+      providers.map((provider) => ({
+        ...provider,
+        name: provider.group,
+        pricingGroup: provider.group,
+      }))
+    );
     ensureManagedProviders.mockResolvedValue(providers);
 
     await expect(syncTuziSessionProviders()).resolves.toBe(true);
-    expect(ensureManagedProviders).toHaveBeenCalledTimes(1);
+    expect(ensureManagedProviders).toHaveBeenCalledWith(['default', 'vip']);
     expect(synchronizeTuziManagedProviders).toHaveBeenCalledWith(providers);
     expect(discoverChangedTuziProviderModels).toHaveBeenCalledWith(
       providers,
-      new Map()
+      new Map([
+        ['tuzi-managed-default', 'sk-default'],
+        ['tuzi-managed-vip', 'sk-vip'],
+      ])
     );
   });
 

--- a/packages/drawnix/src/services/tuzi-managed-provider-models.ts
+++ b/packages/drawnix/src/services/tuzi-managed-provider-models.ts
@@ -13,13 +13,13 @@ export async function discoverAndUseAllTuziProviderModels(
     await runtimeModelDiscovery.discover(
       provider.id,
       tuziV1BaseUrl(),
-      provider.apiKey
+      provider.apiKey,
+      [],
+      { selectAll: true }
     );
-    const allModels = runtimeModelDiscovery.getState(provider.id).discoveredModels;
-    runtimeModelDiscovery.applySelection(
-      provider.id,
-      allModels.map((model) => model.id)
-    );
+    const allModels = runtimeModelDiscovery.getState(
+      provider.id
+    ).discoveredModels;
     return allModels.length;
   } catch (error) {
     const message = error instanceof Error ? error.message : '模型同步失败';

--- a/packages/drawnix/src/services/tuzi-managed-providers.ts
+++ b/packages/drawnix/src/services/tuzi-managed-providers.ts
@@ -29,6 +29,40 @@ const DEFAULT_CAPABILITIES: ProviderProfile['capabilities'] = {
   supportsTools: true,
 };
 
+function valuesEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true;
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (
+      !Array.isArray(left) ||
+      !Array.isArray(right) ||
+      left.length !== right.length
+    ) {
+      return false;
+    }
+    return left.every((value, index) => valuesEqual(value, right[index]));
+  }
+  if (
+    !left ||
+    !right ||
+    typeof left !== 'object' ||
+    typeof right !== 'object'
+  ) {
+    return false;
+  }
+  const leftRecord = left as Record<string, unknown>;
+  const rightRecord = right as Record<string, unknown>;
+  const leftKeys = Object.keys(leftRecord);
+  const rightKeys = Object.keys(rightRecord);
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every(
+      (key) =>
+        Object.prototype.hasOwnProperty.call(rightRecord, key) &&
+        valuesEqual(leftRecord[key], rightRecord[key])
+    )
+  );
+}
+
 function tuziV1BaseUrl(): string {
   return `${tuziEmbeddedConfig.apiBaseUrl?.replace(/\/+$/, '') || ''}/v1`;
 }
@@ -105,13 +139,15 @@ export async function synchronizeTuziManagedProviders(
   providers.forEach((provider) => {
     if (!knownIds.has(provider.id)) merged.push(toProfile(provider, template));
   });
-  await providerProfilesSettings.update(merged);
+  if (!valuesEqual(existing, merged)) {
+    await providerProfilesSettings.update(merged);
+  }
   const validProfileIds = new Set(merged.map((profile) => profile.id));
   const existingCatalogs = providerCatalogsSettings.get();
   const retainedCatalogs = existingCatalogs.filter((catalog) =>
     validProfileIds.has(catalog.profileId)
   );
-  if (retainedCatalogs.length !== existingCatalogs.length) {
+  if (!valuesEqual(retainedCatalogs, existingCatalogs)) {
     await providerCatalogsSettings.update(retainedCatalogs);
   }
 }

--- a/packages/drawnix/src/services/tuzi-provider-selection.ts
+++ b/packages/drawnix/src/services/tuzi-provider-selection.ts
@@ -1,0 +1,63 @@
+const TUZI_PROVIDER_SELECTION_KEY = 'opentu.tuzi.provider-groups.v1';
+
+type SelectionStore = Record<string, string[]>;
+
+function normalizeGroup(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function readStore(): SelectionStore {
+  if (typeof window === 'undefined') return {};
+  try {
+    const value = JSON.parse(
+      window.localStorage.getItem(TUZI_PROVIDER_SELECTION_KEY) || '{}'
+    );
+    return value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as SelectionStore)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+export function getTuziProviderGroupSelection(
+  userId: number | string
+): string[] | null {
+  const value = readStore()[String(userId)];
+  return Array.isArray(value)
+    ? [...new Set(value.map(normalizeGroup).filter(Boolean))]
+    : null;
+}
+
+export function saveTuziProviderGroupSelection(
+  userId: number | string,
+  groups: readonly string[]
+): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const store = readStore();
+    store[String(userId)] = [...new Set(groups.map(normalizeGroup))].filter(
+      Boolean
+    );
+    window.localStorage.setItem(
+      TUZI_PROVIDER_SELECTION_KEY,
+      JSON.stringify(store)
+    );
+  } catch {
+    // localStorage is optional in embedded environments.
+  }
+}
+
+export function clearTuziProviderGroupSelection(userId: number | string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const store = readStore();
+    delete store[String(userId)];
+    window.localStorage.setItem(
+      TUZI_PROVIDER_SELECTION_KEY,
+      JSON.stringify(store)
+    );
+  } catch {
+    // localStorage is optional in embedded environments.
+  }
+}

--- a/packages/drawnix/src/services/tuzi-session-api.ts
+++ b/packages/drawnix/src/services/tuzi-session-api.ts
@@ -78,6 +78,11 @@ export interface TuziManagedProvider {
   rotatedAt: number;
 }
 
+export interface TuziProviderGroup {
+  group: string;
+  displayName: string;
+}
+
 export type TuziQuotaDisplayType = 'USD' | 'CNY' | 'CUSTOM' | 'TOKENS';
 
 export interface TuziDisplayConfig {
@@ -89,6 +94,7 @@ export interface TuziDisplayConfig {
 }
 
 type JsonRecord = Record<string, unknown>;
+const TUZI_REQUEST_TIMEOUT_MS = 15_000;
 
 function asRecord(value: unknown): JsonRecord | null {
   return value && typeof value === 'object' && !Array.isArray(value)
@@ -151,7 +157,8 @@ export class TuziSessionApiClient {
   private async request(
     path: string,
     query?: URLSearchParams,
-    method: 'GET' | 'POST' = 'GET'
+    method: 'GET' | 'POST' = 'GET',
+    body?: string
   ): Promise<unknown> {
     if (!this.systemToken) {
       throw new TuziSessionApiError('NOT_CONFIGURED', '请先填写系统访问令牌');
@@ -171,27 +178,42 @@ export class TuziSessionApiClient {
     if (query) url.search = query.toString();
 
     let response: Response;
+    const controller =
+      typeof AbortController !== 'undefined' ? new AbortController() : null;
+    const timeoutId = controller
+      ? setTimeout(() => controller.abort(), TUZI_REQUEST_TIMEOUT_MS)
+      : undefined;
     try {
       response = await this.fetcher.call(globalThis, url.toString(), {
         method,
         credentials: 'omit',
         headers: {
           Accept: 'application/json',
+          ...(body ? { 'Content-Type': 'application/json' } : {}),
           Authorization: `Bearer ${this.systemToken}`,
           'New-Api-User': this.systemUserId,
         },
+        ...(body ? { body } : {}),
+        ...(controller ? { signal: controller.signal } : {}),
       });
     } catch (error) {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+      if (controller?.signal.aborted) {
+        throw new TuziSessionApiError(
+          'REQUEST_FAILED',
+          'Tuzi API 请求超时，请稍后重试'
+        );
+      }
       throw new TuziSessionApiError(
         'REQUEST_FAILED',
         error instanceof Error ? error.message : '无法连接 Tuzi API'
       );
     }
-
     let payload: unknown = null;
     try {
       payload = await response.json();
     } catch {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
       if (response.ok) {
         throw new TuziSessionApiError(
           'INVALID_RESPONSE',
@@ -200,6 +222,7 @@ export class TuziSessionApiClient {
         );
       }
     }
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
 
     const object = asRecord(payload);
     const code = responseCode(object);
@@ -227,11 +250,24 @@ export class TuziSessionApiClient {
     return object?.data;
   }
 
-  async ensureManagedProviders(): Promise<TuziManagedProvider[]> {
+  async ensureManagedProviders(
+    groups?: readonly string[]
+  ): Promise<TuziManagedProvider[]> {
+    const selectedGroups = groups
+      ? new Set(groups.map((group) => group.trim()).filter(Boolean))
+      : null;
+    const body = selectedGroups
+      ? JSON.stringify({ groups: [...selectedGroups] })
+      : undefined;
     let data: JsonRecord | null;
     try {
       data = asRecord(
-        await this.request('/api/opentu/providers/ensure', undefined, 'POST')
+        await this.request(
+          '/api/opentu/providers/ensure',
+          undefined,
+          'POST',
+          body
+        )
       );
     } catch (error) {
       // Older Tuzi deployments do not expose managed-provider routes. Keep
@@ -252,14 +288,44 @@ export class TuziSessionApiClient {
       ) {
         return [];
       }
+      const managedProvider = {
+        id: provider.id,
+        group: provider.group.trim(),
+        displayName: stringValue(provider.display_name),
+        apiKey: provider.api_key,
+        status: numberValue(provider.status),
+        rotatedAt: numberValue(provider.rotated_at),
+      };
+      if (
+        !managedProvider.group ||
+        (selectedGroups && !selectedGroups.has(managedProvider.group))
+      ) {
+        return [];
+      }
+      return [managedProvider];
+    });
+  }
+
+  async getProviderGroups(): Promise<TuziProviderGroup[]> {
+    let data: unknown;
+    try {
+      data = await this.request('/api/opentu/provider-groups');
+    } catch (error) {
+      if (error instanceof TuziSessionApiError && error.status === 404) {
+        return [];
+      }
+      throw error;
+    }
+    if (!Array.isArray(data)) return [];
+    return data.flatMap((item) => {
+      const group = asRecord(item);
+      if (!group) return [];
+      const groupId = stringValue(group.group).trim();
+      if (!groupId) return [];
       return [
         {
-          id: provider.id,
-          group: provider.group,
-          displayName: stringValue(provider.display_name),
-          apiKey: provider.api_key,
-          status: numberValue(provider.status),
-          rotatedAt: numberValue(provider.rotated_at),
+          group: groupId,
+          displayName: stringValue(group.display_name).trim() || groupId,
         },
       ];
     });

--- a/packages/drawnix/src/services/tuzi-session-api.ts
+++ b/packages/drawnix/src/services/tuzi-session-api.ts
@@ -95,6 +95,8 @@ export interface TuziDisplayConfig {
 
 type JsonRecord = Record<string, unknown>;
 const TUZI_REQUEST_TIMEOUT_MS = 15_000;
+const TUZI_PROVIDER_GROUPS_REQUEST_TIMEOUT_MS = 6_000;
+const TUZI_PROVIDER_GROUPS_RETRY_DELAY_MS = 250;
 
 function asRecord(value: unknown): JsonRecord | null {
   return value && typeof value === 'object' && !Array.isArray(value)
@@ -158,7 +160,8 @@ export class TuziSessionApiClient {
     path: string,
     query?: URLSearchParams,
     method: 'GET' | 'POST' = 'GET',
-    body?: string
+    body?: string,
+    timeoutMs = TUZI_REQUEST_TIMEOUT_MS
   ): Promise<unknown> {
     if (!this.systemToken) {
       throw new TuziSessionApiError('NOT_CONFIGURED', '请先填写系统访问令牌');
@@ -181,7 +184,7 @@ export class TuziSessionApiClient {
     const controller =
       typeof AbortController !== 'undefined' ? new AbortController() : null;
     const timeoutId = controller
-      ? setTimeout(() => controller.abort(), TUZI_REQUEST_TIMEOUT_MS)
+      ? setTimeout(() => controller.abort(), timeoutMs)
       : undefined;
     try {
       response = await this.fetcher.call(globalThis, url.toString(), {
@@ -308,13 +311,34 @@ export class TuziSessionApiClient {
 
   async getProviderGroups(): Promise<TuziProviderGroup[]> {
     let data: unknown;
-    try {
-      data = await this.request('/api/opentu/provider-groups');
-    } catch (error) {
-      if (error instanceof TuziSessionApiError && error.status === 404) {
-        return [];
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        data = await this.request(
+          '/api/opentu/provider-groups',
+          undefined,
+          'GET',
+          undefined,
+          TUZI_PROVIDER_GROUPS_REQUEST_TIMEOUT_MS
+        );
+        break;
+      } catch (error) {
+        if (error instanceof TuziSessionApiError && error.status === 404) {
+          return [];
+        }
+        const retryable =
+          error instanceof TuziSessionApiError &&
+          error.code === 'REQUEST_FAILED' &&
+          (error.status === undefined ||
+            error.status === 408 ||
+            error.status === 429 ||
+            error.status >= 500);
+        if (!retryable || attempt === 1) {
+          throw error;
+        }
+        await new Promise<void>((resolve) =>
+          setTimeout(resolve, TUZI_PROVIDER_GROUPS_RETRY_DELAY_MS)
+        );
       }
-      throw error;
     }
     if (!Array.isArray(data)) return [];
     return data.flatMap((item) => {

--- a/packages/drawnix/src/services/tuzi-session-provider-sync.ts
+++ b/packages/drawnix/src/services/tuzi-session-provider-sync.ts
@@ -1,9 +1,10 @@
 import { isTuziEmbeddedMode } from './tuzi-embedded-config';
-import { hasTuziSystemToken } from './tuzi-token-auth';
+import { getTuziSystemUserId, hasTuziSystemToken } from './tuzi-token-auth';
 import { synchronizeTuziManagedProviders } from './tuzi-managed-providers';
 import { TuziSessionApiClient } from './tuzi-session-api';
 import { discoverChangedTuziProviderModels } from './tuzi-managed-provider-models';
 import { providerProfilesSettings } from '../utils/settings-manager';
+import { getTuziProviderGroupSelection } from './tuzi-provider-selection';
 
 let activeSync: Promise<boolean> | null = null;
 let lastSuccessfulSyncAt = 0;
@@ -25,14 +26,32 @@ export function syncTuziSessionProviders(options?: {
 
   activeSync = (async () => {
     try {
+      const userId = getTuziSystemUserId();
+      let selectedGroups: string[] | null | undefined = userId
+        ? getTuziProviderGroupSelection(userId)
+        : undefined;
+      if (selectedGroups === null && userId) {
+        selectedGroups = providerProfilesSettings
+          .get()
+          .filter((profile) => profile.id.startsWith('tuzi-managed-'))
+          .map((profile) => profile.pricingGroup || profile.name)
+          .filter(Boolean);
+        if (userId && selectedGroups.length > 0) {
+          selectedGroups = [...new Set(selectedGroups)];
+        }
+      }
+      if (selectedGroups === null) {
+        return true;
+      }
       const previousApiKeys = new Map(
         providerProfilesSettings
           .get()
           .filter((profile) => profile.id.startsWith('tuzi-managed-'))
           .map((profile) => [profile.id, profile.apiKey])
       );
-      const providers =
-        await new TuziSessionApiClient().ensureManagedProviders();
+      const providers = await new TuziSessionApiClient().ensureManagedProviders(
+        selectedGroups
+      );
       await synchronizeTuziManagedProviders(providers);
       if (options?.discoverModels !== false) {
         await discoverChangedTuziProviderModels(providers, previousApiKeys);

--- a/packages/drawnix/src/utils/__tests__/runtime-model-discovery.test.ts
+++ b/packages/drawnix/src/utils/__tests__/runtime-model-discovery.test.ts
@@ -859,6 +859,67 @@ describe('runtime-model-discovery', () => {
     });
   });
 
+  it('外部取消模型发现时保留 AbortError', async () => {
+    let requestSignal: AbortSignal | undefined;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_url: string, init?: RequestInit) => {
+        requestSignal = init?.signal || undefined;
+        return new Promise((_resolve, reject) => {
+          requestSignal?.addEventListener(
+            'abort',
+            () => {
+              const error = new Error('aborted');
+              error.name = 'AbortError';
+              reject(error);
+            },
+            { once: true }
+          );
+        });
+      })
+    );
+    vi.doMock('../settings-manager', () => ({
+      LEGACY_DEFAULT_PROVIDER_PROFILE_ID: 'legacy-default',
+      providerCatalogsSettings: {
+        get: () => [],
+        addListener: () => {},
+        removeListener: () => {},
+        update: async () => {},
+      },
+      providerProfilesSettings: {
+        get: () => [],
+        addListener: () => {},
+        removeListener: () => {},
+      },
+      invocationPresetsSettings: {
+        addListener: () => {},
+        removeListener: () => {},
+      },
+      settingsManager: {
+        getSetting: () => ({}),
+        addListener: () => {},
+        removeListener: () => {},
+      },
+    }));
+
+    const { runtimeModelDiscovery } = await import(
+      '../runtime-model-discovery'
+    );
+    const controller = new AbortController();
+    const discovery = runtimeModelDiscovery.discover(
+      'provider-abort',
+      'https://api.example.com/v1',
+      'test-key',
+      [],
+      controller.signal
+    );
+
+    controller.abort();
+
+    await expect(discovery).rejects.toMatchObject({ name: 'AbortError' });
+    expect(requestSignal?.aborted).toBe(true);
+  });
+
   it('优先按接口 category 分类模型', async () => {
     vi.stubGlobal(
       'fetch',

--- a/packages/drawnix/src/utils/runtime-model-discovery.ts
+++ b/packages/drawnix/src/utils/runtime-model-discovery.ts
@@ -33,6 +33,7 @@ import { isTuziEmbeddedMode } from '../services/tuzi-embedded-config';
 import { hasTuziSystemToken } from '../services/tuzi-token-auth';
 
 const LEGACY_CACHE_KEY = 'drawnix-runtime-model-discovery';
+const MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
 
 export interface RemoteModelListItem {
   id: string;
@@ -80,6 +81,20 @@ export interface ManualRuntimeModelInput {
   label?: string;
   description?: string;
   invocation?: ManualRuntimeModelInvocationInput;
+}
+
+export interface RuntimeModelDiscoveryOptions {
+  selectAll?: boolean;
+  signal?: AbortSignal;
+}
+
+function isAbortSignal(value: unknown): value is AbortSignal {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'aborted' in value &&
+    typeof (value as AbortSignal).addEventListener === 'function'
+  );
 }
 
 interface LegacyPersistedRuntimeModelDiscoveryState {
@@ -156,24 +171,42 @@ async function fetchRemoteModelList(
   apiKey: string,
   signal?: AbortSignal
 ): Promise<string> {
-  const response = await fetch(`${baseUrl}/models`, {
-    signal,
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-    },
-  });
+  const controller =
+    typeof AbortController !== 'undefined' ? new AbortController() : null;
+  const timeoutId = controller
+    ? setTimeout(() => controller.abort(), MODEL_DISCOVERY_TIMEOUT_MS)
+    : undefined;
+  const abortFromCaller = () => controller?.abort();
+  if (signal?.aborted) abortFromCaller();
+  signal?.addEventListener('abort', abortFromCaller, { once: true });
+  try {
+    const response = await fetch(`${baseUrl}/models`, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+      ...(controller ? { signal: controller.signal } : {}),
+    });
 
-  const rawText = await response.text();
-  if (!response.ok) {
-    throw new Error(
-      extractDiscoveryErrorMessage(
-        rawText,
-        `获取模型列表失败: HTTP ${response.status}`
-      )
-    );
+    const rawText = await response.text();
+    if (!response.ok) {
+      throw new Error(
+        extractDiscoveryErrorMessage(
+          rawText,
+          `获取模型列表失败: HTTP ${response.status}`
+        )
+      );
+    }
+
+    return rawText;
+  } catch (error) {
+    if (controller?.signal.aborted && !signal?.aborted) {
+      throw new Error('模型列表请求超时，请稍后重试');
+    }
+    throw error;
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+    signal?.removeEventListener('abort', abortFromCaller);
   }
-
-  return rawText;
 }
 
 function buildModelDiscoveryBaseUrls(
@@ -1385,6 +1418,7 @@ function removeLegacyPersistedState(): void {
 class RuntimeModelDiscoveryStore {
   private catalogStates = new Map<string, RuntimeModelDiscoveryState>();
   private listeners = new Set<() => void>();
+  private inFlightDiscoveries = new Map<string, Promise<ModelConfig[]>>();
   private revision = 0;
 
   constructor() {
@@ -1546,6 +1580,15 @@ class RuntimeModelDiscoveryStore {
 
   getRevision(): number {
     return this.revision;
+  }
+
+  getInFlightDiscovery(profileId: string): Promise<ModelConfig[]> | null {
+    for (const [key, discovery] of this.inFlightDiscoveries) {
+      if (key.startsWith(`${profileId}::`)) {
+        return discovery;
+      }
+    }
+    return null;
   }
 
   getState(
@@ -1868,16 +1911,65 @@ class RuntimeModelDiscoveryStore {
     baseUrl: string,
     apiKey: string,
     fallbackBaseUrls: string[] = [],
-    signal?: AbortSignal
+    optionsOrSignal: RuntimeModelDiscoveryOptions | AbortSignal = {}
   ): Promise<ModelConfig[]> {
     const trimmedApiKey = apiKey.trim();
     if (!trimmedApiKey) {
       throw new Error('缺少 API Key');
     }
 
-    const state = this.getCatalogState(profileId);
     const normalizedBaseUrl = normalizeModelApiBaseUrl(baseUrl);
     const signature = buildDiscoverySignature(normalizedBaseUrl, trimmedApiKey);
+    const options = isAbortSignal(optionsOrSignal)
+      ? { signal: optionsOrSignal }
+      : optionsOrSignal;
+
+    if (options.signal) {
+      return this.discoverInternal(
+        profileId,
+        normalizedBaseUrl,
+        trimmedApiKey,
+        signature,
+        fallbackBaseUrls,
+        options
+      );
+    }
+
+    const discoveryKey = `${profileId}::${signature}::selectAll=${
+      options.selectAll === true ? '1' : '0'
+    }`;
+    const existingDiscovery = this.inFlightDiscoveries.get(discoveryKey);
+    if (existingDiscovery) {
+      return existingDiscovery;
+    }
+
+    const discovery = this.discoverInternal(
+      profileId,
+      normalizedBaseUrl,
+      trimmedApiKey,
+      signature,
+      fallbackBaseUrls,
+      options
+    );
+    this.inFlightDiscoveries.set(discoveryKey, discovery);
+    const clearInFlight = () => {
+      if (this.inFlightDiscoveries.get(discoveryKey) === discovery) {
+        this.inFlightDiscoveries.delete(discoveryKey);
+      }
+    };
+    void discovery.then(clearInFlight, clearInFlight);
+    return discovery;
+  }
+
+  private async discoverInternal(
+    profileId: string,
+    normalizedBaseUrl: string,
+    trimmedApiKey: string,
+    signature: string,
+    fallbackBaseUrls: string[],
+    options: RuntimeModelDiscoveryOptions
+  ): Promise<ModelConfig[]> {
+    const state = this.getCatalogState(profileId);
 
     this.setCatalogState(
       profileId,
@@ -1895,7 +1987,7 @@ class RuntimeModelDiscoveryStore {
       normalizedBaseUrl,
       trimmedApiKey,
       fallbackBaseUrls,
-      signal
+      options.signal
     );
 
     let parsed: unknown;
@@ -1934,15 +2026,16 @@ class RuntimeModelDiscoveryStore {
         .filter((model) => (model.tags || []).includes('manual'))
         .map((model) => model.id)
     );
-    const selectedModelIds =
-      state.signature === signature
-        ? normalizeSelectedModelIds(discoveredModels, state.selectedModelIds)
-        : normalizeSelectedModelIds(
-            discoveredModels,
-            state.selectedModelIds.filter((modelId) =>
-              manualModelIds.has(modelId)
-            )
-          );
+    const selectedModelIds = options.selectAll
+      ? discoveredModels.map((model) => model.id)
+      : state.signature === signature
+      ? normalizeSelectedModelIds(discoveredModels, state.selectedModelIds)
+      : normalizeSelectedModelIds(
+          discoveredModels,
+          state.selectedModelIds.filter((modelId) =>
+            manualModelIds.has(modelId)
+          )
+        );
     const models = buildSelectedModels(discoveredModels, selectedModelIds);
 
     this.setCatalogState(profileId, {

--- a/qa/2026-08-20-Tuzi账户与自动分组Provider-人工测试文档.md
+++ b/qa/2026-08-20-Tuzi账户与自动分组Provider-人工测试文档.md
@@ -2,7 +2,7 @@
 
 **创建日期**：2026-08-20
 
-**测试范围**：验证 OpenTu 嵌入 Tuzi 后的 Session 登录、账户信息、日志读取、按授权分组自动创建 Provider、更新 Key、模型调用，以及本机和局域网访问下的登录态一致性。
+**测试范围**：验证 OpenTu 嵌入 Tuzi 后的 Session 登录、账户信息、日志读取、按用户选择的授权分组创建 Provider、更新 Key、模型调用，以及本机和局域网访问下的登录态一致性。
 
 **关联变更**：`openspec/changes/add-tuzi-session-account-workspace`
 
@@ -36,11 +36,12 @@
 
 ## 已执行验证
 
-- [x] `npx nx typecheck drawnix` 通过。
-- [x] Tuzi 账户面板、Tuzi Session API、托管 Provider 和设置管理共 4 个测试文件、22 个测试通过。
+- [x] `pnpm exec tsc --noEmit -p packages/drawnix/tsconfig.json` 通过。
+- [x] `pnpm exec nx build drawnix` 通过，包括 Web 类型检查、Web 应用、Service Worker 和 Drawnix 库构建。
+- [x] Tuzi 账户面板、模型下拉、Tuzi Session API、托管 Provider 和模型发现共 7 个测试文件、59 个测试通过。
 - [x] 覆盖凭据化 GET/POST、Session 过期映射、账户/日志响应解析和托管 Provider 同步。
 - [x] 覆盖账户面板隐藏“近 30 天消费”和“可用模型”，顶部显示登录/同步状态，余额页支持换新 Key，日志页支持分页查看。
-- [x] 覆盖日志页展示时间、渠道、用户、模型、输出、详情、金额列；日志详情仅在点击日志行后展开，计费过程和原始日志 JSON 需要再次点击才显示。
+- [x] 覆盖日志页按 API 站风格展示时间、渠道、用户、分组、模型、用时、详情、金额列；时间支持展开箭头，渠道/分组使用标签，用户显示头像，详情仅在点击日志行后展开。
 - [x] 覆盖日志页提供“列设置”，可选择展示时间、渠道、用户、令牌、分组、类型、调用状态、模型、用时、输入、输出、IP、重试、详情、金额、Request ID 和上游 Request ID。
 - [x] 覆盖模型下拉中会显示已启用且配置完整但尚未同步出模型的供应商分组。
 - [x] 覆盖设置页供应商开关支持关闭 default，但会阻止关闭最后一个启用中的供应商。
@@ -49,23 +50,23 @@
 - [x] 覆盖公开 Tuzi API 域名不被当前页面主机改写。
 - [x] 覆盖换新 Key 请求明确要求后端删除旧 Token，并在后端明确返回删除失败时阻止成功状态。
 - [x] 本地 CORS 接口验证返回指定 Origin 和 `Access-Control-Allow-Credentials: true`。
-- [ ] 真实浏览器登录、自动建 Key、更新 Key、模型调用和跨设备访问待人工执行。
+- [ ] 真实浏览器登录、分组勾选后建 Key、更新 Key、模型调用和跨设备访问待人工执行。
 
 建议回归命令：
 
 ```bash
 cd /Users/lkj/Desktop/working/opentu
 
-npx nx typecheck drawnix
+pnpm exec tsc --noEmit -p packages/drawnix/tsconfig.json
 
-npx vitest run \
+NODE_OPTIONS=--no-experimental-webstorage pnpm exec vitest run \
   packages/drawnix/src/components/settings-dialog/TuziAccountPanel.test.tsx \
-  packages/drawnix/src/services/__tests__/tuzi-session-api.test.ts \
-  packages/drawnix/src/services/__tests__/tuzi-managed-providers.test.ts \
-  packages/drawnix/src/utils/__tests__/settings-manager.test.ts \
-  packages/drawnix/src/utils/__tests__/model-grouping.test.ts \
   packages/drawnix/src/components/ai-input-bar/ModelDropdown.test.tsx \
-  packages/drawnix/src/components/settings-dialog/__tests__/provider-toggle-utils.test.ts
+  packages/drawnix/src/services/__tests__/tuzi-managed-providers.test.ts \
+  packages/drawnix/src/services/__tests__/tuzi-managed-provider-models.test.ts \
+  packages/drawnix/src/services/__tests__/tuzi-session-api.test.ts \
+  packages/drawnix/src/services/__tests__/tuzi-session-provider-sync.test.ts \
+  packages/drawnix/src/utils/__tests__/runtime-model-discovery.test.ts
 ```
 
 ## 场景 1：本机 localhost 登录与账户加载
@@ -82,9 +83,9 @@ npx vitest run \
 - [ ] “账户余额”页显示正确额度、累计用量和请求次数。
 - [ ] “账户余额”页可以看到授权分组及“换新 Key”按钮。
 - [ ] “日志”页显示最近调用，并可通过分页查看全部记录。
-- [ ] “日志”页表头包含时间、渠道、用户、模型、输出、详情、金额。
+- [ ] “日志”页按 API 站风格显示时间、渠道、用户、分组、模型、用时、详情、金额；金额与右侧边框保持间距。
 - [ ] “日志”页提供“列设置”，可勾选要展示的字段，并至少保留一列。
-- [ ] “日志”页默认不直接展开详情；点击日志行或“查看详情”后显示摘要字段，计费过程和原始日志 JSON 仍保持收起，分别点击“展开内容”后才显示。
+- [ ] “日志”页默认不直接展开详情；点击日志行后显示计费摘要，计费过程和原始日志 JSON 仍保持收起，分别点击“展开内容”后才显示。
 - [ ] “日志”页可通过上一页/下一页切换分页，页码和当前显示范围同步更新。
 - [ ] 授权分组数量与 Tuzi 账户权限一致。
 - [ ] 不显示“近 30 天消费”和“可用模型”区块。
@@ -142,19 +143,20 @@ npx vitest run \
 
 **状态**：交互逻辑和类型检查已验证；完整浏览器流程待人工。
 
-## 场景 5：首次登录自动创建分组 Provider
+## 场景 5：首次登录选择分组并创建 Provider
 
 1. 使用没有 OpenTu 托管 Token 的测试账户登录。
-2. 第一次打开 OpenTu 的 Tuzi 账户页。
-3. 检查“分组供应商”和 OpenTu 现有供应商配置。
-4. 在 Tuzi API 后端查询该用户现有 Token 记录。
+2. 第一次打开 OpenTu 的 Tuzi 账户页，等待可用分组列表出现。
+3. 只勾选需要连接的授权分组，点击“应用分组并连接”。
+4. 检查“分组供应商”和 OpenTu 现有供应商配置。
+5. 在 Tuzi API 后端查询该用户现有 Token 记录。
 
 **预期结果**：
 
-- [ ] 每个用户授权分组自动创建或复用一个托管 Token。
-- [ ] OpenTu 为每个分组同步一个现有 Provider 配置。
+- [ ] 只有用户勾选的授权分组创建或复用托管 Token。
+- [ ] OpenTu 只为勾选的分组同步 Provider 配置。
 - [ ] Provider URL 使用固定 Tuzi API 地址。
-- [ ] 用户不需要手动创建、复制或填写 API Key。
+- [ ] 用户不需要手动创建、复制或填写 API Key；未勾选分组不显示换新 Key 操作。
 - [ ] 重复打开或刷新不重复创建 Token，不增加重复 Provider。
 - [ ] 未授权分组不会创建 Token 或 Provider。
 - [ ] 不新增数据库表，Token 继续写入 Tuzi API 现有 Token 存储。
@@ -313,7 +315,7 @@ npx vitest run \
 - [ ] 本机 `localhost` 完整流程通过。
 - [ ] 局域网另一台电脑完整流程通过。
 - [ ] Session 过期、重新登录和刷新恢复通过。
-- [ ] 自动建 Provider 幂等且仅覆盖授权分组。
+- [ ] 自动建 Provider 幂等且仅覆盖用户已选并获授权的分组。
 - [ ] 更新 Key 后新 Key 可用、旧 Key 按设计失效。
 - [ ] 至少一个文本模型和一个图片模型真实调用通过，logs 与额度记录一致。
 - [ ] 独立模式回归通过。


### PR DESCRIPTION
## 变更说明

- 首次连接或替换系统令牌时，先选择需要启用的供应商分组。
- 仅为已勾选分组创建并同步 API Key、Provider 和模型，未选择分组不加载也不展示替换入口。
- 将账户、Provider、模型改为分阶段加载，日志保持按需加载。
- 增加请求超时、模型发现去重和无变化更新抑制，减少同步期间的重复全局广播与界面卡顿。
- 为模型加载提供明确状态，并对大模型列表使用虚拟化渲染。
- 将日志列表调整为 API 站风格，并修正右侧布局间距。
- 修复预览环境中分组接口偶发阻塞后的错误状态：只读分组请求采用 6 秒超时和一次有限重试；连续失败时不再误显示“暂无可用分组”，并禁止提交空选择。
- 补充相关测试、既有 OpenSpec 变更内容和 QA 记录。

## 测试

- `pnpm --filter @aitu/drawnix exec vitest run src/services/__tests__/tuzi-session-api.test.ts`：20/20 通过。
- `NODE_OPTIONS=--localstorage-file=<临时文件> pnpm --filter @aitu/drawnix exec vitest run src/components/settings-dialog/TuziAccountPanel.test.tsx`：14/14 通过。
- `pnpm --filter @aitu/drawnix exec tsc --noEmit`：通过。
- 目标文件 Prettier 检查：通过。

## QA / DOC

- 已更新本次功能对应的既有 OpenSpec 和 QA 文档。
- 本次预览问题修复不改变部署、配置、依赖或公开接口，因此未新增 QA/DOC 文件。

## 注意事项

- 只读分组接口仅对网络失败、HTTP 408、429 和 5xx 自动重试一次；令牌、权限及其他确定性 4xx 错误不会重试。
- 创建 Key 的 `ensure` 和替换 Key 的 `rotate` 仍保持单次写请求，避免重复副作用。
- GitHub `main` CI 中，本 PR 相关的 Tuzi 测试通过；此前完整任务因仓库其它测试及既有 AI Chat bundle size 门槛失败，最新提交的远程检查以 GitHub 页面结果为准。
- Vercel 检查因仓库部署授权不足失败，需要仓库维护方授权；Netlify 预览由最新提交重新部署。
- 未使用真实账户令牌执行浏览器端到端验收；需在评审环境验证首次连接、替换令牌、分组勾选、模型刷新和日志展示。
- 当前环境未安装 OpenSpec CLI，因此未执行严格 OpenSpec 校验。
- 浏览器端 Provider 凭据处理沿用项目现有兼容性方案，本 PR 未扩大该安全边界。
- 无数据库迁移，无新增环境变量。
- 回滚方式：回退本 PR 提交即可。
