### PR TITLE
修复：提高生产图片同源代理请求体上限

### DIFF
--- a/scripts/opentu-production.conf
+++ b/scripts/opentu-production.conf
@@ -60,7 +60,7 @@ server {
         proxy_buffering off;
         proxy_read_timeout 600s;
         proxy_send_timeout 600s;
-        client_max_body_size 100m;
+        client_max_body_size 256m;
     }
 
     location ^~ /__opentu_tuzi_proxy__/apius/ {
@@ -72,7 +72,7 @@ server {
         proxy_buffering off;
         proxy_read_timeout 600s;
         proxy_send_timeout 600s;
-        client_max_body_size 100m;
+        client_max_body_size 256m;
     }
 
     location ^~ /__opentu_tuzi_proxy__/apicdn/ {
@@ -84,7 +84,7 @@ server {
         proxy_buffering off;
         proxy_read_timeout 600s;
         proxy_send_timeout 600s;
-        client_max_body_size 100m;
+        client_max_body_size 256m;
     }
 
     location ^~ /__opentu_tuzi_proxy__/sydney/ {
@@ -96,7 +96,7 @@ server {
         proxy_buffering off;
         proxy_read_timeout 600s;
         proxy_send_timeout 600s;
-        client_max_body_size 100m;
+        client_max_body_size 256m;
     }
 
     location ^~ /__opentu_tuzi_proxy__/ourzhishi/ {
@@ -108,7 +108,7 @@ server {
         proxy_buffering off;
         proxy_read_timeout 600s;
         proxy_send_timeout 600s;
-        client_max_body_size 100m;
+        client_max_body_size 256m;
     }
 
     location ^~ /__opentu_tuzi_proxy__/ourzhishi-sz/ {
@@ -120,7 +120,7 @@ server {
         proxy_buffering off;
         proxy_read_timeout 600s;
         proxy_send_timeout 600s;
-        client_max_body_size 100m;
+        client_max_body_size 256m;
     }
 
     # 静态资源长缓存


### PR DESCRIPTION
## 问题描述

多张或大尺寸参考图通过 `/images/edits` 提交时，multipart 请求可能超过 OpenTu 生产同源代理原有的 `100m` 限制。Nginx 返回 `413 text/html` 后，前端会将其显示为“Tuzi 同源代理未生效”。

## 修复思路

- 将六个固定 Tuzi 生产代理入口的 `client_max_body_size` 从 `100m` 统一提升到 `256m`
- 不增加单图大小限制
- 不修改 API 站限制或前端请求逻辑
- 保持固定上游白名单、`proxy_request_buffering off` 和既有超时配置不变

## 复现路径

1. 在 OpenTu 选择支持 `/images/edits` 的图片模型
2. 添加多张或大尺寸参考图，使 multipart 总请求体超过 `100m`
3. 提交后 Nginx 返回 413 HTML，前端显示同源代理失败

## 验证

- `git diff --check` 通过
- 已确认六个生产代理入口均为 `client_max_body_size 256m`
- 已确认生产配置中不再存在 `client_max_body_size 100m`

部署后需在生产服务器执行 `nginx -t` 并 reload Nginx。